### PR TITLE
Updating Destination Host

### DIFF
--- a/detections/sigma/dev_tunnels__aka_visual_studio_dev_tunnel__network_sigma.yml
+++ b/detections/sigma/dev_tunnels__aka_visual_studio_dev_tunnel__network_sigma.yml
@@ -5,7 +5,7 @@ logsource:
 detection:
   selection:
     DestinationHostname|endswith:
-    - learn.microsoft.com/en-us/azure/developer/dev-tunnels/overview
+    - '*.devtunnels.ms'
   condition: selection
 id: d241c4b6-c437-4e78-9942-ae798e840204
 status: experimental


### PR DESCRIPTION
The destination host lead to Microsoft DevTunnels Website, should have been lead to the actual devtunnels domain. Updated if from the following sigma rule. 

https://github.com/SigmaHQ/sigma/blob/master/rules/windows/dns_query/dns_query_win_devtunnels_communication.yml