### PR TITLE
SimplehelpRMM new sigma rule 

### DIFF
--- a/detections/sigma/simplehelp_rmm_remote_persistence_execution.yml
+++ b/detections/sigma/simplehelp_rmm_remote_persistence_execution.yml
@@ -1,0 +1,26 @@
+title: Malicious Remote Access Execution Via Simple Help RMM Software
+id: bfc9f08f-59c2-4346-807e-a67b6d7621fd
+status: stable
+description: This rule can detects additional remote access tools, often masquerading as legitimate software, to maintain persistence and access to compromised systems. In one observed incident, adversaries installed the Simple Help Remote Monitoring and Management (RMM) tool after gaining initial access through ScreenConnect.
+references:
+    - https://www.huntress.com/blog/slashandgrab-screen-connect-post-exploitation-in-the-wild-cve-2024-1709-cve-2024-1708
+author: Phyo Paing Htun
+date: 2024/10/16
+tags:
+    - attack.persistence
+    - attack.t1543.003
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        Image|contains:
+            - '\ProgramData\JWrapper-Remote Access\JWAppsSharedConfig\restricted\'
+            - '\ProgramData\JWrapper-Remote Access\JWAppsSharedConfig\'
+        Image|endswith:
+            - '\SimpleService.exe'
+            - '\serviceconfig.xml'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/yaml/updatesimplehelp.yaml
+++ b/yaml/updatesimplehelp.yaml
@@ -1,0 +1,50 @@
+Name: SimpleHelp
+Description: SimpleHelp is a remote monitoring and management (RMM) tool. More information
+  will be added as it becomes available.
+Author: 'Phyo Paing Htun'
+Created: ''
+LastModified: 16/10/2024
+Details:
+  Website: 'https://simple-help.com/'
+  PEMetadata:
+    Filename: ''
+    OriginalFileName: ''
+    Description: ''
+  Privileges: ''
+  Free: ''
+  Verification: ''
+  SupportedOS:
+  - windows
+  Capabilities: []
+  Vulnerabilities: []
+  InstallationPaths:
+  - simplehelpcustomer.exe
+  - simpleservice.exe
+  - simplegatewayservice.exe
+  - remote access.exe
+  - windowslauncher.exe
+  - spsrv.exe
+  - serviceconfig.xml
+Artifacts:
+  Disk: []
+  EventLog: []
+  Registry: []
+  Network:
+  - Description: Known remote domains
+    Domains:
+    - user_managed
+    - simple-help.com
+    - 51.255.19.178
+    - 51.255.19.179
+    Ports:
+    - 443
+Detections:
+- Sigma: https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_network_sigma.yml
+  Description: Detects potential network activity of SimpleHelp RMM tool
+- Sigma: https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_processes_sigma.yml
+  Description: Detects potential processes activity of SimpleHelp RMM tool
+References:
+- https://simple-help.com/remote-support
+- https://www.huntress.com/blog/slashandgrab-screen-connect-post-exploitation-in-the-wild-cve-2024-1709-cve-2024-1708
+- https://www.group-ib.com/blog/muddywater-infrastructure/
+Acknowledgement: []


### PR DESCRIPTION
Hi, I have updated the sigma rule for SImple Help RMM persistence execution activities and known domains from following threat reports.
https://www.group-ib.com/blog/muddywater-infrastructure/
https://www.huntress.com/blog/slashandgrab-screen-connect-post-exploitation-in-the-wild-cve-2024-1709-cve-2024-1708