### PR TITLE
Corrected typo and formatting issue

### DIFF
--- a/yaml/dameware.yaml
+++ b/yaml/dameware.yaml
@@ -19,8 +19,8 @@ Details:
   InstallationPaths:
   - SolarWinds-Dameware-DRS*.exe
   - DameWare Mini Remote Control*.exe
-  - "C:\\Windows\\dwrcs\\*\n c:\\Program File\\SolarWinds\\Dameware Mini Remote Control\\\
-    *"
+  - 'C:\Windows\dwrcs\*'
+  - 'C:\Program Files\SolarWinds\Dameware Mini Remote Control\*'
   - dntus*.exe
   - dwrcs.exe
   - '*\dwrcs\*'


### PR DESCRIPTION
When analyzing the LOLRMM JSON resource I noticed that there was a DameWare installation path with a carriage return (\n) character and 'C:\Program File\' (rather than Program _Files_) which I believe were added in error. It looks like two separate entries had been inadvertently combined into a single YAML item with a \n character inserted in the middle. I researched the DameWare install paths and believe I have corrected the issue.