### PR TITLE
Remove incorrect path for MEGAsync

### DIFF
--- a/yaml/megasync.yaml
+++ b/yaml/megasync.yaml
@@ -19,7 +19,6 @@ Details:
   InstallationPaths:
   - C:\Users\*\AppData\Local\MEGAsync\*
   - '*Users\*\AppData\Local\MEGAsync\*'
-  - '*Users\*\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\*'
   - '*ProgramData\MEGAsync\*'
   - '*\MEGAsyncSetup64.exe'
   - '*\MEGAupdater.exe'


### PR DESCRIPTION
Hi there!

One of the paths for MEGAsync is to wide, it is definitely a mistake. Let's remove it.