### PR TITLE
Update NinjaRMM definition & Sigma (network) rule

### DIFF
--- a/detections/sigma/ninjarmm_network_sigma.yml
+++ b/detections/sigma/ninjarmm_network_sigma.yml
@@ -9,6 +9,18 @@ detection:
     - '*.ninjaone.com'
     - resources.ninjarmm.com
     - ninjaone.com
+    - ninjarmm.net
+    - '*.ninjarmm.net'
+    - rmmservice.eu
+    - '*.rmmservice.eu'
+    - rmmservice.eu
+    - '*.rmmservice.eu'
+    - rmmservice.com.au
+    - '*.rmmservice.com.au'
+    - rmmservice.ca
+    - '*.rmmservice.ca'
+    - ninja-backup.com
+    - '*.ninja-backup.com'
   condition: selection
 id: 36fd47e6-13f9-4eb0-a826-8f34e3e1dc0e
 status: experimental

--- a/yaml/ninjarmm.yaml
+++ b/yaml/ninjarmm.yaml
@@ -43,6 +43,7 @@ Artifacts:
     - rmmservice.ca
     - '*.rmmservice.ca'
     - ninja-backup.com
+    - '*.ninja-backup.com'
     Ports: []
 Detections:
 - Sigma: https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/ninjarmm_network_sigma.yml

--- a/yaml/ninjarmm.yaml
+++ b/yaml/ninjarmm.yaml
@@ -32,6 +32,17 @@ Artifacts:
     - '*.ninjaone.com'
     - resources.ninjarmm.com
     - ninjaone.com
+    - ninjarmm.net
+    - '*.ninjarmm.net'
+    - rmmservice.eu
+    - '*.rmmservice.eu'
+    - rmmservice.eu
+    - '*.rmmservice.eu'
+    - rmmservice.com.au
+    - '*.rmmservice.com.au'
+    - rmmservice.ca
+    - '*.rmmservice.ca'
+    - ninja-backup.com
     Ports: []
 Detections:
 - Sigma: https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/ninjarmm_network_sigma.yml


### PR DESCRIPTION
Extend the domains included in the NinjaRMM definition according to their published endpoints (https://ninjarmm.zendesk.com/hc/en-us/articles/211406886-Allowlist-Whitelist-Information - does require a Ninja login to access).

Update the associated Sigma detection rule (network) to match the domain definitions. 