### PR TITLE
Fix nxserver definition

### DIFF
--- a/website/public/api/rmm_tools.json
+++ b/website/public/api/rmm_tools.json
@@ -15374,7 +15374,7 @@
             "Vulnerabilities": [],
             "InstallationPaths": [
                 "nomachine*.exe",
-                "nxservice*.ese",
+                "nxservice*.exe",
                 "nxd.exe"
             ]
         },


### PR DESCRIPTION
Pretty sure that the InstallationPath for NoMachine should contain `nxserver.exe`, not `neserver.ese`