### PR TITLE
Improve KQL Query Coverage

### DIFF
--- a/website/components/home.tsx
+++ b/website/components/home.tsx
@@ -335,7 +335,7 @@ let RMMUrl = RMMList
 DeviceNetworkEvents
 | where TimeGenerated > ago(1h)
 | where ActionType == @"ConnectionSuccess"
-| where RemoteUrl has_any(RMMUrl)
+| where RemoteUrl has_any(RMMUrl.URIClean)
 | where not (RemoteUrl has_any(ApprovedRMM))
 | summarize arg_max(TimeGenerated, *) by DeviceId`}								
 									</EuiCodeBlock>

--- a/website/components/home.tsx
+++ b/website/components/home.tsx
@@ -325,7 +325,13 @@ function Contents() {
 let ApprovedRMM = dynamic(["nomachine.com", "ivanti.com", "getgo.com"]); // Your approved RMM domains
 let RMMList = externaldata(URI: string, RMMTool: string)
     [h'https://raw.githubusercontent.com/magicsword-io/LOLRMM/main/website/public/api/rmm_domains.csv'];
-let RMMUrl = RMMList | project URI;
+let RMMUrl = RMMList
+| project URIClean = case(
+    URI startswith "*.", replace_string(URI, "*.", ""),
+    URI startswith "*", replace_string(URI, "*", ""),
+    URI !startswith "*" and URI contains "*", replace_regex(URI, @".+?\*", ""),
+    URI
+    );
 DeviceNetworkEvents
 | where TimeGenerated > ago(1h)
 | where ActionType == @"ConnectionSuccess"


### PR DESCRIPTION
KQL doesn't recognize `*` as a wildcard. This results in 206 URIs not being detected by the current KQL query. The query in the PR normalizes those URLs to improve the coverage. There are still URIs with the full URL (blah/et/blah/) which can't be covered because of no SSL inspection. 