### PR TITLE
Correct KQL

### DIFF
--- a/detections/kql/generic_rmm_detection.yml
+++ b/detections/kql/generic_rmm_detection.yml
@@ -7,9 +7,9 @@ query: "// Detecting Unauthorized RMM Instances in Your MDE Environment\n\nlet S
   \ = dynamic(\"YOUR_APPROVED_RMM_DOMAINS\"); // E.g. \"bomgarcloud.com\" - Replace\
   \ with your approved RMM domains\nlet RMMList = externaldata(URI: string, RMMTool:\
   \ string)\n    [h'https://raw.githubusercontent.com/magicsword-io/LOLRMM/main/website/public/api/rmm_domains.csv'];\n\
-  let RMMUrl = RMMList | project URI;\n\nDeviceNetworkEvents\n| where TimeGenerated\
+  let RMMUrl = RMMList | project URI;\n\nDeviceNetworkEvents\n| where Timestamp\
   \ > ago(1h)\n| where ActionType == @\"ConnectionSuccess\"\n| where RemoteUrl has_any(RMMUrl)\n\
-  | where not (RemoteUrl has_any(SanctionRMM))\n| summarize arg_max(TimeGenerated,\
+  | where not (RemoteUrl has_any(SanctionRMM))\n| summarize arg_max(Timestamp,\
   \ *) by DeviceId"
 references:
 - https://github.com/magicsword-io/LOLRMM

--- a/website/components/home.tsx
+++ b/website/components/home.tsx
@@ -338,6 +338,9 @@ DeviceNetworkEvents
 										<p>
 											Replace <code>YOUR_APPROVED_RMM_DOMAINS</code> with your organization's approved RMM domains to exclude them from the detection.
 										</p>
+										<p>
+											<strong>Note for Microsoft Sentinel users:</strong> If you're using this query in Microsoft Sentinel, replace <code>Timestamp</code> with <code>TimeGenerated</code> in both the WHERE clause and the summarize function.
+										</p>
 									</EuiText>
 								</div>
 							) : selectedTabId === 'splunk' ? (

--- a/website/components/home.tsx
+++ b/website/components/home.tsx
@@ -327,11 +327,11 @@ let RMMList = externaldata(URI: string, RMMTool: string)
     [h'https://raw.githubusercontent.com/magicsword-io/LOLRMM/main/website/public/api/rmm_domains.csv'];
 let RMMUrl = RMMList | project URI;
 DeviceNetworkEvents
-| where TimeGenerated > ago(1h)
+| where Timestamp > ago(1h)
 | where ActionType == @"ConnectionSuccess"
 | where RemoteUrl has_any(RMMUrl)
 | where not (RemoteUrl has_any(ApprovedRMM))
-| summarize arg_max(TimeGenerated, *) by DeviceId`}								
+| summarize arg_max(Timestamp, *) by DeviceId`}								
 									</EuiCodeBlock>
 									<EuiSpacer size="s" />
 									<EuiText size="s">


### PR DESCRIPTION
## Summary

Fixed the KQL query field mismatch issue from PR #102:

- **Updated** `detections/kql/generic_rmm_detection.yml` to use `Timestamp` instead of `TimeGenerated` (correct for Microsoft Defender for Endpoint)
- **Added** a note to the website explaining that Sentinel users should replace `Timestamp` with `TimeGenerated`

This optimizes the query for MDE (more popular) while providing clear guidance for Sentinel users, resolving the PR feedback without over-engineering.