### PR TITLE
Add sigma-gen workflow and fix formatting

### DIFF
--- a/.github/workflows/sigma-gen.yml
+++ b/.github/workflows/sigma-gen.yml
@@ -1,0 +1,35 @@
+name: Generate Sigma Rules
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'yaml/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-sigma:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: '3.10'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Generate Sigma rules
+        run: python bin/sigma-gen.py
+
+      - name: Git Auto Commit
+        uses: stefanzweifel/git-auto-commit-action@v4.15.4
+        with:
+          commit_message: Update Sigma rules [skip ci]
+          file_pattern: detections/sigma/*.yml


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sigma-gen.yml` to auto-generate Sigma rules when `yaml/` files change on main
- Fixes `bin/sigma-gen.py`: deterministic UUIDs via `uuid5` and proper YAML value quoting

Supersedes #152 — removes the 487 generated sigma detection files that were causing merge conflicts. The CI workflow will generate those automatically. Credits to @Niicolaa.

## Test plan
- [ ] Verify workflow triggers on `yaml/` changes to main
- [ ] Run `python bin/sigma-gen.py` locally to confirm correct output
- [ ] Manually trigger workflow via `workflow_dispatch` after merge