### PR TITLE
Add Lunixar RMM

### DIFF
--- a/yaml/lunixar.yaml
+++ b/yaml/lunixar.yaml
@@ -1,0 +1,90 @@
+Name: Lunixar
+Category: RMM
+Description: Lunixar is a Remote Monitoring and Management (RMM) platform by Lunixar
+  SAS de CV (Mexico) for MSPs and IT teams. Provides remote access from the browser
+  and a Windows app, script execution and scheduling, hardware/software inventory,
+  process and service management, and real-time alerting. Has been observed abused
+  in the wild, renamed as Googlemeet.msi and distributed via the phishing domain
+  mymeetinggoogle.com, and as eDocument-*.msi for social engineering lures.
+Author: Michael Haag
+Created: '2026-04-23'
+LastModified: '2026-04-23'
+Details:
+    Website: 'https://lunixar.com/en/'
+    PEMetadata:
+        Filename: Lunixar.exe
+        OriginalFileName: ''
+        Description: ''
+    Privileges: ''
+    Free: ''
+    Verification: ''
+    SupportedOS:
+        - Windows
+    Capabilities:
+        - Remote access (browser and Windows app)
+        - Script execution and scheduling
+        - Hardware and software inventory
+        - Process and service management
+        - Real-time CPU/RAM/disk alerting
+    Vulnerabilities: []
+    InstallationPaths:
+        - C:\Program Files\Lunixar\*
+        - '*\Lunixar\Lunixar.exe'
+        - '*\Lunixar\Lunixar.dll'
+        - '*\Lunixar\Lunixar.Agent.Core.dll'
+        - '*\Lunixar\LunixarRemote.exe'
+        - '*\Lunixar\LunixarRemote.dll'
+        - '*\Lunixar\LunixarUpdater.exe'
+        - '*\Lunixar\LunixarUpdater.dll'
+        - LunixarRMM*.msi
+        - Googlemeet.msi
+        - eDocument-*.msi
+Artifacts:
+    Disk:
+        - Description: Main agent DLL
+          File: C:\Program Files\Lunixar\Lunixar.dll
+          Type: File
+        - Description: Agent core library
+          File: C:\Program Files\Lunixar\Lunixar.Agent.Core.dll
+          Type: File
+        - Description: Remote access executable
+          File: C:\Program Files\Lunixar\LunixarRemote.exe
+          Type: File
+        - Description: Remote access library
+          File: C:\Program Files\Lunixar\LunixarRemote.dll
+          Type: File
+        - Description: Auto-updater executable
+          File: C:\Program Files\Lunixar\LunixarUpdater.exe
+          Type: File
+        - Description: Auto-updater library
+          File: C:\Program Files\Lunixar\LunixarUpdater.dll
+          Type: File
+    EventLog:
+        - Description: Service event log source
+          EventId: ''
+          Provider: Lunixar rmm-client service
+    Registry:
+        - Description: Windows service registration
+          Path: HKLM\System\CurrentControlSet\Services\LunixarRMM
+          Key: ImagePath
+          Value: '"C:\Program Files\Lunixar\Lunixar.exe"'
+    Network:
+        - Description: Known remote domains
+          Domains:
+              - '*.lunixar.com'
+              - lunixar.com
+              - app.lunixar.com
+              - socket.lunixar.com
+              - downloads.lunixar.com
+              - devrmm.lunixar.com
+          Ports:
+              - 23501
+        - Description: Known abuse/phishing domains distributing renamed Lunixar MSI
+          Domains:
+              - mymeetinggoogle.com
+          Ports: []
+Detections: []
+References:
+    - https://lunixar.com/en/
+    - https://www.virustotal.com/gui/file/3160414da55882b9f03bae5aa76f0dc3c6cdb9e27e9091d9dac6fa610bd94c33
+Acknowledgement: []


### PR DESCRIPTION
## Summary

Adds Lunixar RMM (Lunixar SAS de CV, Mexico) — observed abused in the wild as a renamed installer for social engineering.

### Abuse Observed
- **Googlemeet.msi** — Lunixar MSI renamed to impersonate Google Meet, distributed via phishing domain mymeetinggoogle.com
- **eDocument-*.msi** — Renamed with UUID-style filenames to mimic document downloads
- 13 MSI variants observed on VT communicating with lunixar.com (all April 2026)
- 0/77 VT detections across all variants
- Signed by **LUNIXAR SAS DE CV** via GoGetSSL

### Artifacts (verified on Windows)
| File | Type |
|---|---|
| Lunixar.exe | Main service executable (LunixarRMM service) |
| Lunixar.dll | Main agent DLL |
| Lunixar.Agent.Core.dll | Agent core library |
| LunixarRemote.exe / .dll | Remote access component |
| LunixarUpdater.exe / .dll | Auto-updater |

### Network
- socket.lunixar.com:23501 — WebSocket C2 channel
- downloads.lunixar.com — Update distribution
- app.lunixar.com — Management portal
- mymeetinggoogle.com — Phishing distribution domain

### Validation
- bin/validate.py passes with no errors