### PR TITLE
Enrich SimpleHelp from Huntress ransomware-abuse blog — closes #156

### DIFF
--- a/yaml/simplehelp.yaml
+++ b/yaml/simplehelp.yaml
@@ -1,9 +1,9 @@
 Name: SimpleHelp
 Category: RMM
-Description: SimpleHelp is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
+Description: SimpleHelp is a remote monitoring and management (RMM) tool. It has been observed being abused by threat actors as a persistence and remote-access vector during ransomware operations, including campaigns delivering the "Crazy" ransomware (VoidCrypt family) reported by Huntress in February 2026.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-05-04'
 Details:
     Website: 'https://simple-help.com/'
     PEMetadata:
@@ -13,7 +13,8 @@ Details:
     Privileges: ''
     Free: ''
     Verification: ''
-    SupportedOS: []
+    SupportedOS:
+        - Windows
     Capabilities: []
     Vulnerabilities: []
     InstallationPaths:
@@ -22,16 +23,41 @@ Details:
         - simplegatewayservice.exe
         - remote access.exe
         - windowslauncher.exe
+        - spsrv.exe
+        - serviceconfig.xml
+        - C:\ProgramData\JWrapper-Remote Access\*
+        - '%APPDATA%\JWrapper-SimpleSetup\*'
+        - vhost.exe
 Artifacts:
-    Disk: []
+    Disk:
+        - File: C:\ProgramData\JWrapper-Remote Access\
+          Description: Default SimpleHelp "Remote Access" service installation directory observed in Huntress reporting on Crazy ransomware operations.
+          OS: Windows
+        - File: '%APPDATA%\JWrapper-SimpleSetup\'
+          Description: SimpleHelp customer-side setup/wrapper directory dropped by the SimpleSetup installer (e.g. windowslauncher.exe, SimpleSetupECompatibility.exe).
+          OS: Windows
     EventLog: []
-    Registry: []
+    Registry:
+        - Path: HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\SimpleSetup
+          Description: Uninstall key written by the SimpleHelp SimpleSetup installer; URLUpdateInfo points to https://www.simple-help.com/media/static/SimpleSetup/.
     Network:
         - Description: Known remote domains
           Domains:
               - user_managed
               - simple-help.com
-          Ports: []
+              - 51.255.19.178
+              - 51.255.19.179
+          Ports:
+              - 443
+        - Description: Threat-actor-controlled SimpleHelp / Net Monitor infrastructure observed by Huntress during the "Crazy" (VoidCrypt) ransomware campaign documented in February 2026. NOT vendor-legitimate — these are attacker-operated SimpleHelp gateways and update servers.
+          Domains:
+              - dronemaker.org
+              - telesupportgroup.com
+              - microuptime.com
+              - 192.144.34.42
+              - 160.191.182.41
+          Ports:
+              - 443
 Detections:
     - Sigma: https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/simplehelp_network_sigma.yml
       Description: Detects potential network activity of SimpleHelp RMM tool
@@ -39,7 +65,14 @@ Detections:
       Description: Detects potential processes activity of SimpleHelp RMM tool
 References:
     - https://simple-help.com/remote-support
-Acknowledgement: []
+    - https://www.huntress.com/blog/employee-monitoring-simplehelp-abused-in-ransomware-operations
+    - https://www.huntress.com/blog/slashandgrab-screen-connect-post-exploitation-in-the-wild-cve-2024-1709-cve-2024-1708
+    - https://www.group-ib.com/blog/muddywater-infrastructure/
+Acknowledgement:
+    - Person: KapAttack133
+      Handle: KapAttack133
+    - Person: Phyo Paing Htun
+      Handle: ''
 CodeSigning:
     certificates:
         - signer_name: SimpleHelp Ltd


### PR DESCRIPTION
## Summary

Enriches `yaml/simplehelp.yaml` with IOCs from the February 2026 Huntress investigation [Employee Monitoring & SimpleHelp Abused in Ransomware Operations](https://www.huntress.com/blog/employee-monitoring-simplehelp-abused-in-ransomware-operations). Closes #156 (filed by @KapAttack133).

The Huntress reporting documents two cases where a single threat actor deployed SimpleHelp alongside Net Monitor for Employees as a remote-access / persistence vector before delivering "Crazy" (VoidCrypt family) ransomware. Only items the blog or Huntress's IOC table directly confirms have been added — nothing was invented.

### What was added to `yaml/simplehelp.yaml`

**Description**
- Reframed to call out the ransomware-abuse pattern observed by Huntress.

**Details.SupportedOS**
- Added `Windows`.

**Details.InstallationPaths**
- `C:\ProgramData\JWrapper-Remote Access\*` — default SimpleHelp service install dir, observed in Huntress reporting and confirmed via VirusTotal sandbox traces of the legitimate SimpleHelp installer.
- `%APPDATA%\JWrapper-SimpleSetup\*` — SimpleHelp customer-side wrapper directory.
- `vhost.exe` — renamed SimpleHelp binary used by the threat actor in the Huntress cases.
- `spsrv.exe`, `serviceconfig.xml` — folded in from the duplicate `yaml/updatesimplehelp.yaml` (originally cited from Group-IB's MuddyWater report).

**Artifacts.Disk**
- `C:\ProgramData\JWrapper-Remote Access\` — service installation directory.
- `%APPDATA%\JWrapper-SimpleSetup\` — installer/wrapper directory dropped by `SimpleSetup-windows32-online.exe`.

**Artifacts.Registry**
- `HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\SimpleSetup` — SimpleSetup uninstall key with `URLUpdateInfo` pointing to `https://www.simple-help.com/media/static/SimpleSetup/`.

**Artifacts.Network** (new entry, clearly flagged as TA-controlled)
- Domains: `dronemaker.org`, `telesupportgroup.com`, `microuptime.com`
- IPs: `192.144.34.42`, `160.191.182.41`
- Port: `443`
- The entry's `Description` explicitly notes these are attacker-operated SimpleHelp gateways/update servers from the Crazy ransomware campaign — **NOT vendor-legitimate `simple-help.com` infrastructure**.
- Also folded the MuddyWater IPs `51.255.19.178` / `51.255.19.179` and port `443` into the existing "Known remote domains" entry (carried over from `updatesimplehelp.yaml`).

**References**
- Added the Huntress blog. Retained the existing `simple-help.com` reference and pulled in the MuddyWater + ScreenConnect refs that lived in the duplicate yaml.

**Acknowledgement**
- `KapAttack133` — issue reporter for #156.
- `Phyo Paing Htun` — author of `yaml/updatesimplehelp.yaml` whose contributions are folded in here.

### CVEs

The Huntress blog **does not** cite any CVEs (CVE-2024-57726/57727/57728 are publicly attributed to SimpleHelp ≤5.5.7 and tracked by CISA AA25-163A, but they are not in scope for this Huntress-sourced enrichment). `Details.Vulnerabilities` is intentionally left empty in this PR — please open a separate issue if you'd like the CISA-cited CVEs added from a different source.

### Duplication note

`yaml/updatesimplehelp.yaml` is a duplicate SimpleHelp entry created on 2025-03-05. This PR folds its unique contributions (MuddyWater IPs, `spsrv.exe`, `serviceconfig.xml`, ScreenConnect/Group-IB refs) into the canonical `yaml/simplehelp.yaml`. Suggest a follow-up consolidation PR to delete `yaml/updatesimplehelp.yaml`. I did not delete it in this PR to keep the change scope focused on the issue.

## Test plan

- [x] `python3 bin/fix_yaml_formatting.py yaml/simplehelp.yaml` → "Successfully fixed"
- [x] `python3 bin/validate.py -y yaml/ -s bin/spec/lolrmm.spec.json` → "No Errors found"
- [x] `python3 -m yamllint -c .yamllint yaml/simplehelp.yaml` → clean
- [ ] CI green