### PR TITLE
intel(psexec): add psexec64.exe to InstallationPaths

### DIFF
--- a/yaml/psexec.yaml
+++ b/yaml/psexec.yaml
@@ -18,6 +18,7 @@ Details:
     Vulnerabilities: []
     InstallationPaths:
         - psexec.exe
+        - psexec64.exe
         - psexecsvc.exe
 Artifacts:
     Disk: []


### PR DESCRIPTION
Closes #95.

Adds the 64-bit variant `psexec64.exe` to the PsExec InstallationPaths. The 64-bit Sysinternals binary ships in the same Sysinternals download as 32-bit `psexec.exe` and is the default that runs on modern x64 endpoints — without it cataloged, hunt rules generated from `rmm_tools.json` miss every modern PsExec invocation.