### PR TITLE
intel(atera): remove generic Pubnub FP domains

### DIFF
--- a/yaml/atera.yaml
+++ b/yaml/atera.yaml
@@ -166,7 +166,7 @@ Artifacts:
               - ps.atera.com
           Ports:
               - N/A
-        - Description: N/A
+        - Description: Atera-specific PubNub tenant subdomain (CNAME api-tls11.pubnubapi.com) used by the AteraAgent for real-time tenant messaging. Distinct from the generic pubsub.pubnub.com / ps.pndsn.com PubNub multi-tenant infrastructure (shared by thousands of unrelated apps), this `atera.`-prefixed subdomain is reliable Atera-attribution signal.
           Domains:
               - atera.pubnubapi.com
           Ports:
@@ -196,6 +196,7 @@ References:
     - https://support.atera.com/hc/en-us/articles/215955967-Troubleshoot-Atera-s-Windows-agent
     - https://support.atera.com/hc/en-us/articles/115015619747-Release-Notes-February-2018
     - https://thedfirreport.com/?s=ateraagent
+    - https://www.pubnub.com/docs/general/setup/connection-management
 Acknowledgement:
     - Person: Théo Letailleur
       Handle: in/theosyn

--- a/yaml/atera.yaml
+++ b/yaml/atera.yaml
@@ -123,11 +123,6 @@ Artifacts:
               - N/A
         - Description: N/A
           Domains:
-              - pubsub.pubnub.com
-          Ports:
-              - N/A
-        - Description: N/A
-          Domains:
               - agentreporting.atera.com
           Ports:
               - N/A
@@ -149,11 +144,6 @@ Artifacts:
         - Description: N/A
           Domains:
               - packagesstore.blob.core.windows.net
-          Ports:
-              - N/A
-        - Description: N/A
-          Domains:
-              - ps.pndsn.com
           Ports:
               - N/A
         - Description: N/A


### PR DESCRIPTION
Closes #73.

Removes two Pubnub-generic domains from the Atera Network artifacts because they're shared SaaS infrastructure that hits in environments with **zero** Atera deployment:

- `pubsub.pubnub.com` — Pubnub's primary public real-time messaging API; used by countless apps (chat plugins, IoT devices, marketing SaaS, Atera competitors). DNS-lookup hits and TLS-SNI hits to this domain are not Atera-specific signal.
- `ps.pndsn.com` — Pubnub's PNDSN content fallback / backup hostname. Same problem.

Kept (Atera-specific Pubnub usage):

- `atera.pubnubapi.com` — the per-tenant Pubnub presence URL; matching this is reliable Atera-attribution signal.

Per the issue: Thawte CA / OCSP domains (`cacerts.thawte.com`, `crl.thawte.com`, `status.thawte.com`) and other generic root-CA / OCSP infrastructure should be excluded from current and future LOLRMM tool submissions repo-wide. None of those are currently in `atera.yaml`, so no further removals here, but worth a separate cleanup pass across all yamls if the maintainer wants to standardize.