### PR TITLE
Enrich NetBird from Trellix CFO-targeted spear-phishing campaign — closes #81

### DIFF
--- a/yaml/netbird.yaml
+++ b/yaml/netbird.yaml
@@ -1,9 +1,9 @@
 Name: NetBird
 Category: RAT
-Description: NetBird is an open-source VPN and remote access platform that provides secure peer-to-peer connectivity. It has been observed being leveraged in spear phishing campaigns across Europe, Africa, Canada, the Middle East, and South Asia, targeting financial executives and CFOs. The tool was deployed as part of multi-stage phishing attacks by threat actors including APT MuddyWater.
+Description: NetBird is an open-source WireGuard-based VPN and remote access platform that provides secure peer-to-peer connectivity. It has been observed being abused in spear-phishing campaigns across Europe, Africa, Canada, the Middle East, and South Asia, targeting CFOs and other financial executives at banks, energy companies, insurers, and investment firms. In May 2025, Trellix documented a campaign that impersonated a Rothschild & Co recruiter, leading victims through a deceptive CAPTCHA to download a ZIP containing a malicious VBScript that silently installed NetBird and OpenSSH MSI packages, created a hidden local administrator account, enabled RDP, and persisted the NetBird agent via a scheduled task — granting attackers persistent peer-to-peer remote access. Hunt.io and Trellix link the infrastructure to APT MuddyWater (Earth Vetala) based on overlap with previously documented activity (IP 192.3.95.152 / Gophish on TCP 3333).
 Author: Michael Haag
 Created: '2026-01-15'
-LastModified: '2026-01-15'
+LastModified: '2026-05-04'
 Details:
     Website: https://netbird.io/
     PEMetadata:
@@ -16,6 +16,15 @@ Details:
         - Filename: netbird
           OriginalFileName: ''
           Description: NetBird client binary for Linux/macOS
+        - Filename: netbird_installer_*_windows_amd64.msi
+          OriginalFileName: ''
+          Description: NetBird Windows MSI installer (canonical naming pattern from official GitHub releases, e.g. netbird_installer_0.70.4_windows_amd64.msi). Renamed to netbird.msi in the May 2025 Trellix-reported campaign.
+        - Filename: netbird_installer_*_windows_amd64.exe
+          OriginalFileName: netbird_installer.exe
+          Description: NetBird Windows EXE installer signed by NetBird GmbH (formerly Wiretrustee UG). Description string "Connect your devices into a secure WireGuard-based overlay network with SSO, MFA, and granular access controls." Product "Netbird".
+        - Filename: wintun.dll
+          OriginalFileName: wintun.dll
+          Description: WireGuard Wintun TUN driver shipped with the NetBird Windows client.
     Privileges: User
     Free: Yes (Open Source)
     Verification: Open Source
@@ -39,6 +48,13 @@ Details:
         - /usr/bin/netbird
         - /usr/local/bin/netbird
         - /opt/netbird/*
+        - /Applications/NetBird UI.app
+        - /etc/netbird/install.conf
+        - C:\bin\netbird.msi
+        - C:\bin\OpenSSH.msi
+        - C:\bin\cis.vbs
+        - C:\bin\trm.zip
+        - C:\temper\trm
         - netbird.exe
         - netbird-ui.exe
         - netbird
@@ -56,6 +72,27 @@ Artifacts:
         - File: /var/log/netbird/*
           Description: NetBird log files
           OS: Linux
+        - File: /etc/netbird/install.conf
+          Description: NetBird installation manifest written by the official install.sh — records the package manager type used.
+          OS: Linux
+        - File: /Applications/NetBird UI.app
+          Description: NetBird UI application bundle on macOS (installed via .pkg or Homebrew cask).
+          OS: macOS
+        - File: C:\bin\netbird.msi
+          Description: NetBird MSI dropped by the May 2025 Trellix-reported CFO spear-phishing campaign (silently installed by cis.vbs / Stage-2 VBS).
+          OS: Windows
+        - File: C:\bin\OpenSSH.msi
+          Description: OpenSSH server MSI dropped alongside NetBird in the May 2025 CFO spear-phishing campaign (used to enable persistent SSH access).
+          OS: Windows
+        - File: C:\bin\cis.vbs
+          Description: Stage-2 VBScript dropper that installs NetBird and OpenSSH (May 2025 Trellix-reported campaign).
+          OS: Windows
+        - File: C:\bin\trm.zip
+          Description: ZIP staging archive containing NetBird and OpenSSH MSIs (renamed from "trm" payload fetched from the C2).
+          OS: Windows
+        - File: C:\temper\trm
+          Description: Initial payload staging path used by the Stage-1 VBScript before being renamed to trm.zip (May 2025 campaign).
+          OS: Windows
     EventLog:
         - EventID: 4688
           Description: Process creation event for netbird.exe
@@ -63,24 +100,89 @@ Artifacts:
         - EventID: 7045
           Description: Service installation event for NetBird
           OS: Windows
-    Registry: []
+        - EventID: 4720
+          ProviderName: Microsoft-Windows-Security-Auditing
+          LogFile: Security.evtx
+          Description: A user account was created. Observed during May 2025 CFO spear-phishing campaign — local account "user" created with password "Bs@202122".
+          OS: Windows
+        - EventID: 4732
+          ProviderName: Microsoft-Windows-Security-Auditing
+          LogFile: Security.evtx
+          Description: A member was added to a security-enabled local group. Observed during May 2025 CFO spear-phishing campaign — "user" added to Administrators / Administrateurs.
+          OS: Windows
+        - EventID: 4698
+          ProviderName: Microsoft-Windows-Security-Auditing
+          LogFile: Security.evtx
+          Description: A scheduled task was created. Observed during May 2025 CFO spear-phishing campaign — task "ForceNetbirdRestart" created to restart NetBird one minute after boot.
+          OS: Windows
+    Registry:
+        - Path: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList\user
+          Description: Registry key set to 0 to hide the attacker-created local administrator account "user" from the Windows logon screen (May 2025 Trellix-reported CFO spear-phishing campaign).
+        - Path: HKLM\SYSTEM\CurrentControlSet\Services\Netbird
+          Description: Netbird Windows service registration (created by NetBird MSI installer; configured by the campaign for delayed automatic start at boot).
     Network:
-        - Description: Known remote domains
+        - Description: NetBird control-plane and client endpoints (canonical, from official documentation)
           Domains:
               - netbird.io
               - '*.netbird.io'
               - api.netbird.io
+              - app.netbird.io
               - signal.netbird.io
+              - relay.netbird.io
+              - login.netbird.io
+              - pkgs.netbird.io
           Ports:
               - 443
+              - 33073
               - 51820
+        - Description: Threat actor C2 / staging infrastructure observed in the May 2025 Trellix-reported CFO spear-phishing campaign and Hunt.io follow-up. Overlaps with APT MuddyWater (Earth Vetala) infrastructure.
+          Domains:
+              - 192.3.95.152
+              - 198.46.178.135
+              - googl-6c11f.firebaseapp.com
+              - googl-6c11f.web.app
+              - googl-165a0.web.app
+              - cloud-ed980.firebaseapp.com
+              - cloud-233f9.firebaseapp.com
+              - my-sharepoint-inc.com
+              - my1cloudlive.com
+              - my2cloudlive.com
+              - web-16fe.app
+          Ports:
+              - 80
+              - 443
+              - 3333
+    Other:
+        - Type: NetworkInterface
+          Value: wt0
+        - Type: NetworkInterface
+          Value: utun100
+        - Type: ServiceName
+          Value: Netbird
+        - Type: SetupKey
+          Value: E48E4A70-4CF4-4A77-946B-C8E50A60855A
+        - Type: ScheduledTask
+          Value: ForceNetbirdRestart
+        - Type: LocalUser
+          Value: user
+        - Type: SHA256
+          Value: b8c84e7047080589cc2e1dc955c78349f8d37d0e79160a040096e1ffcf89d869
+        - Type: SignerSubject
+          Value: NetBird GmbH (current; chain GlobalSign GCC R45 EV CodeSigning CA 2020 -> GlobalSign Code Signing Root R45)
+        - Type: SignerSubject
+          Value: Wiretrustee UG (haftungsbeschränkt) (legacy; chain SSL.com EV Code Signing Intermediate CA RSA R3 -> SSL.com EV Root Certification Authority RSA R2)
 Detections: []
 References:
     - https://github.com/magicsword-io/LOLRMM/issues/81
     - https://www.trellix.com/en-in/blogs/research/a-flyby-on-the-cfos-inbox-spear-phishing-campaign-targeting-financial-executives-with-netbird-deployment/
     - https://hunt.io/blog/apt-muddywater-deploys-multi-stage-phishing-to-target-cfos
+    - https://netbird.io/knowledge-hub/netbird-response-to-spear-phishing-campaign-targeting-financial-executives
+    - https://www.centripetal.ai/threat-research/threat-actors-abuse-netbird-in-spear-phishing-campaign-targeting-finance-executives
+    - https://thehackernews.com/2025/06/fake-recruiter-emails-target-cfos-using.html
     - https://netbird.io/use-cases/remote-access
+    - https://docs.netbird.io/how-to/installation
     - https://github.com/netbirdio/netbird
+    - https://github.com/netbirdio/netbird/releases/latest
 Acknowledgement:
     - Person: jacobholtz
       Handle: '@jacobholtz'


### PR DESCRIPTION
## Summary

Enriches `yaml/netbird.yaml` with Trellix-documented IOCs from the May 2025 spear-phishing campaign that targeted CFOs and finance executives across Europe, Africa, Canada, the Middle East, and South Asia. Lure impersonated a Rothschild & Co recruiter; victims were funneled through a deceptive CAPTCHA → ZIP → VBScript → silent install of NetBird and OpenSSH MSIs → hidden local administrator account → enabled RDP → scheduled-task persistence on the NetBird agent. Hunt.io and Trellix link the infrastructure to APT MuddyWater (Earth Vetala) based on overlap with previously documented activity (192.3.95.152, Gophish on TCP 3333). NetBird's response page confirms the disclosed setup key was used 197 times over 65 days from a single account.

Closes #81. Reported by @jacobholtz.

## What's added

**Description** rewritten to capture the campaign chain and attribution.

**`Details.PEMetadata`** — adds canonical Windows MSI/EXE installer naming pattern (`netbird_installer_*_windows_amd64.{msi,exe}`) sourced from the official GitHub releases, and `wintun.dll` (WireGuard TUN driver shipped with the Windows client).

**`Details.InstallationPaths`** — adds `/Applications/NetBird UI.app`, `/etc/netbird/install.conf`, and the campaign-specific staging paths `C:\bin\{netbird.msi,OpenSSH.msi,cis.vbs,trm.zip}` and `C:\temper\trm`.

**`Artifacts.Disk`** — campaign-staged file paths with attribution to Trellix May 2025 report; canonical macOS app bundle and Linux install manifest.

**`Artifacts.EventLog`** — adds `4720` (user creation), `4732` (admins group add), `4698` (scheduled task creation) tied to the campaign's local user `user` / `Bs@202122` and `ForceNetbirdRestart` task. Existing 4688 / 7045 preserved.

**`Artifacts.Registry`** — `HKLM\...\SpecialAccounts\UserList\user` (hides attacker account from logon screen) and `HKLM\SYSTEM\CurrentControlSet\Services\Netbird` (legitimate service registration, configured by the campaign for delayed-auto start).

**`Artifacts.Network`** — splits into two entries: (1) canonical NetBird control-plane endpoints (`api`, `app`, `signal`, `relay`, `login`, `pkgs`.netbird.io + ports 443/33073/51820), (2) threat-actor C2/staging infrastructure (`192.3.95.152`, `198.46.178.135`, `googl-*.firebaseapp.com`, `googl-*.web.app`, `cloud-*.firebaseapp.com`, `my-sharepoint-inc.com`, `my{1,2}cloudlive.com`, `web-16fe.app` + ports 80/443/3333).

**`Artifacts.Other`** — NetBird tunnel interface names (`wt0`, `utun100`), Windows service name (`Netbird`), the disclosed campaign setup key (`E48E4A70-4CF4-4A77-946B-C8E50A60855A`), the `ForceNetbirdRestart` scheduled task, the `user` local account, the SHA256 of a current legitimately-signed installer (`b8c84e7047...`), and both signer subjects (current `NetBird GmbH` / GlobalSign EV chain; legacy `Wiretrustee UG (haftungsbeschränkt)` / SSL.com EV chain — useful for older fleet samples).

**`References`** — adds Hunt.io, NetBird's own response page, Centripetal, The Hacker News, official NetBird docs, and GitHub releases. Existing Trellix and netbird.io URLs preserved.

**`Acknowledgement`** — `@jacobholtz` and `@ruppde` preserved (no new acks).

## Validation

- `python3 bin/fix_yaml_formatting.py yaml/netbird.yaml` — clean
- `python3 bin/validate.py -y yaml/ -s bin/spec/lolrmm.spec.json` — `No Errors found`
- `python3 -m yamllint -c .yamllint yaml/netbird.yaml` — clean

## Test plan

- [ ] CI: schema validator passes
- [ ] CI: yamllint passes
- [ ] Site build picks up new IOCs on the NetBird tool page