### PR TITLE
Fix generated MDX frontmatter escaping

### DIFF
--- a/bin/jinja2_templates/rmm.md.j2
+++ b/bin/jinja2_templates/rmm.md.j2
@@ -1,6 +1,6 @@
 ---
-description = "{{ rmm.Description | clean_multiline }}"
-title = "{{ rmm.Name }}"
+description: {{ dump(rmm.Description | clean_multiline) }}
+title: {{ dump(rmm.Name) }}
 ---
 
 


### PR DESCRIPTION
## Summary
- writes generated MDX frontmatter as valid YAML keys
- serializes title and description with json.dumps so colons, quotes, bullets, and long multiline descriptions parse safely

## Root cause
Rodex RMM has a long multiline description containing a colon before bullet text. The previous template emitted frontmatter as raw `description = "..."`, which gray-matter/js-yaml could not parse during `next build`.

## Validation
- `poetry run python bin/site.py -v`
- `npm install` in `website`
- `npm run build` in `website`
- rendered all 297 tool pages through the updated template and parsed their frontmatter with PyYAML