### PR TITLE
Fix generated workflow push races

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,14 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git config --global push.default simple
         git add .
-        git diff --quiet && git diff --staged --quiet || (git commit -m "Update generated site files [skip ci]" && 
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git HEAD:main)
+        git diff --quiet && git diff --staged --quiet && exit 0
+        git commit -m "Update generated site files [skip ci]"
+        for attempt in 1 2 3; do
+          git pull --rebase origin main
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git HEAD:main && exit 0
+          sleep $((attempt * 5))
+        done
+        exit 1
       working-directory: website
 
 # Deployment job

--- a/.github/workflows/sigma-gen.yml
+++ b/.github/workflows/sigma-gen.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.0
+        with:
+          token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4.7.1
@@ -26,10 +28,20 @@ jobs:
         run: pip install pyyaml
 
       - name: Generate Sigma rules
-        run: python bin/sigma-gen.py
+        run: python bin/sigma-gen.py --skip-yaml-update
 
-      - name: Git Auto Commit
-        uses: stefanzweifel/git-auto-commit-action@v4.15.4
-        with:
-          commit_message: Update Sigma rules [skip ci]
-          file_pattern: detections/sigma/*.yml
+      - name: Commit and push if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add detections/sigma/*.yml
+          git diff --quiet && git diff --staged --quiet && exit 0
+          git commit -m "Update Sigma rules [skip ci]"
+          for attempt in 1 2 3; do
+            git pull --rebase origin main
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:${GITHUB_REF} && exit 0
+            sleep $((attempt * 5))
+          done
+          exit 1

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -29,4 +29,11 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git config --global push.default simple
           git add rmm-tools-count.json
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Update RMM Tools count badge" && git pull --rebase origin main && git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:${GITHUB_REF})
+          git diff --quiet && git diff --staged --quiet && exit 0
+          git commit -m "Update RMM Tools count badge"
+          for attempt in 1 2 3; do
+            git pull --rebase origin main
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:${GITHUB_REF} && exit 0
+            sleep $((attempt * 5))
+          done
+          exit 1

--- a/bin/sigma-gen.py
+++ b/bin/sigma-gen.py
@@ -1,11 +1,90 @@
+import argparse
 import os
+import ntpath
+import re
 import yaml
 from datetime import date
 import uuid
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 
 # Namespace UUID for generating deterministic rule IDs
 LOLRMM_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+SIGMA_RULE_PREFIX = "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/"
+UNQUOTED_SPECIAL_VALUE = re.compile(
+    r"(?m)^(\s*(?:-\s+|[^:\n]+:\s+))([*%@`][^#\n]*)$"
+)
+
+
+def yaml_date(value: Any) -> str:
+    if isinstance(value, date):
+        return value.strftime("%Y-%m-%d")
+    return str(value).strip()
+
+
+def listify(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def normalize_detection(detection: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = {}
+    for key, value in detection.items():
+        if key == "condition":
+            normalized[key] = value
+        elif isinstance(value, dict):
+            normalized[key] = {
+                subkey: [str(item) for item in listify(subvalue)]
+                for subkey, subvalue in value.items()
+            }
+        else:
+            normalized[key] = value
+    return normalized
+
+
+def normalize_rule(rule: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = {}
+    for key in ("title", "id", "status", "description", "author", "level"):
+        normalized[key] = str(rule.get(key, "")).strip()
+
+    normalized["date"] = yaml_date(rule.get("date", ""))
+    if "modified" in rule:
+        normalized["modified"] = yaml_date(rule["modified"])
+
+    normalized["references"] = [str(item) for item in listify(rule.get("references"))]
+    normalized["tags"] = [str(item) for item in listify(rule.get("tags"))]
+    normalized["logsource"] = rule.get("logsource", {})
+    normalized["detection"] = normalize_detection(rule.get("detection", {}))
+    normalized["falsepositives"] = [
+        str(item) for item in listify(rule.get("falsepositives"))
+    ]
+    return normalized
+
+
+def load_existing_sigma_rule(filepath: str) -> Optional[Dict[str, Any]]:
+    if not os.path.exists(filepath):
+        return None
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        # Some legacy generated rules have unquoted wildcard/path values such
+        # as *.example.com or %localappdata%, which YAML treats as syntax.
+        # Quote those for comparison without changing the file on disk.
+        sanitized = UNQUOTED_SPECIAL_VALUE.sub(r"\1'\2'", content)
+        data = yaml.safe_load(sanitized)
+
+    return data if isinstance(data, dict) else None
+
+
+class IndentDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
+        return super().increase_indent(flow, False)
 
 
 def extract_artifacts(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
@@ -30,7 +109,7 @@ def extract_artifacts(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
     details = yaml_data.get("Details", {})
     if isinstance(details, dict):
         artifacts["processes"] = [
-            os.path.basename(item)
+            ntpath.basename(item)
             for item in details.get("InstallationPaths", []) or []
             if isinstance(item, str) and item.lower().endswith(".exe")
         ]
@@ -112,6 +191,22 @@ def write_sigma_rule(rule: Dict[str, Any], filepath: str) -> None:
         f.write(f"level: {rule['level']}\n")
 
 
+def write_sigma_rule_if_changed(rule: Dict[str, Any], filepath: str) -> None:
+    existing_rule = load_existing_sigma_rule(filepath)
+    if existing_rule:
+        # Preserve already-published metadata so reruns do not churn every rule.
+        rule["id"] = str(existing_rule.get("id", rule["id"]))
+        if "date" in existing_rule:
+            rule["date"] = yaml_date(existing_rule["date"])
+        if "modified" in existing_rule:
+            rule["modified"] = yaml_date(existing_rule["modified"])
+
+        if normalize_rule(existing_rule) == normalize_rule(rule):
+            return
+
+    write_sigma_rule(rule, filepath)
+
+
 def generate_sigma_rules(yaml_file: str, output_dir: str) -> List[Dict[str, Any]]:
     with open(yaml_file, "r") as f:
         data = yaml.safe_load(f)
@@ -186,10 +281,10 @@ def generate_sigma_rules(yaml_file: str, output_dir: str) -> List[Dict[str, Any]
             output_file = f"{safe_name}_{artifact_type}_sigma.yml"
             full_output_path = os.path.join(output_dir, output_file)
 
-            # Write with custom formatting
-            write_sigma_rule(rule, full_output_path)
+            # Write with custom formatting only when content actually changes.
+            write_sigma_rule_if_changed(rule, full_output_path)
 
-            github_url = f"https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/{output_file}"
+            github_url = f"{SIGMA_RULE_PREFIX}{output_file}"
             generated_rules.append(
                 {
                     "Sigma": github_url,
@@ -209,23 +304,40 @@ def update_yaml_with_sigma_rules(
     if "Detections" not in data:
         data["Detections"] = []
 
-    # Remove existing generated rules
-    data["Detections"] = [
+    manual_rules = [
         rule
         for rule in data["Detections"]
         if not rule.get("Sigma", "").startswith(
-            "https://github.com/magicsword-io/LOLRMM/blob/main/detections/sigma/"
+            SIGMA_RULE_PREFIX
         )
     ]
 
-    # Add new generated rules
-    data["Detections"].extend(sigma_rules)
+    existing_generated_urls = {
+        rule.get("Sigma")
+        for rule in data["Detections"]
+        if isinstance(rule, dict)
+        and rule.get("Sigma", "").startswith(SIGMA_RULE_PREFIX)
+    }
+    generated_urls = {rule["Sigma"] for rule in sigma_rules}
 
-    with open(yaml_file, "w") as f:
-        yaml.dump(data, f, sort_keys=False)
+    if existing_generated_urls == generated_urls:
+        return
+
+    data["Detections"] = manual_rules + sigma_rules
+
+    with open(yaml_file, "w", encoding="utf-8") as f:
+        yaml.dump(
+            data,
+            f,
+            Dumper=IndentDumper,
+            sort_keys=False,
+            allow_unicode=True,
+            indent=4,
+            width=4096,
+        )
 
 
-def main() -> None:
+def main(update_yaml: bool = True) -> None:
     yaml_dir = "yaml/"
     output_dir = "detections/sigma/"
     os.makedirs(output_dir, exist_ok=True)
@@ -234,12 +346,21 @@ def main() -> None:
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             yaml_file = os.path.join(yaml_dir, filename)
             sigma_rules = generate_sigma_rules(yaml_file, output_dir)
-            update_yaml_with_sigma_rules(yaml_file, sigma_rules)
+            if update_yaml:
+                update_yaml_with_sigma_rules(yaml_file, sigma_rules)
 
+    yaml_status = "and YAML update " if update_yaml else ""
     print(
-        f"[+] Sigma rule generation and YAML update complete. Files saved in {output_dir}"
+        f"[+] Sigma rule generation {yaml_status}complete. Files saved in {output_dir}"
     )
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-yaml-update",
+        action="store_true",
+        help="Only write Sigma rules; leave source YAML files unchanged.",
+    )
+    args = parser.parse_args()
+    main(update_yaml=not args.skip_yaml_update)


### PR DESCRIPTION
## Summary

Fixes the generated-commit workflows that were losing races when another workflow pushed to `main` first.

## What changed

- Replaced the Sigma auto-commit action with an explicit commit, rebase, retry, and push flow.
- Added the same rebase/retry push behavior to the site deploy and badge update workflows.
- Made `bin/sigma-gen.py` avoid rewriting unchanged Sigma rules by preserving existing IDs/dates and comparing normalized rule content.
- Fixed Windows executable basename extraction on Linux runners with `ntpath.basename`.
- Added `--skip-yaml-update` so CI can generate Sigma rules without reformatting source YAML files.

## Root cause

Multiple `main` workflows generate commits and push back to the branch. When one workflow pushed first, later workflows tried to push from an older checkout and failed with `fetch first`. Sigma generation also rewrote many unchanged rules because rule dates were stamped with the current date and existing generated metadata was not preserved.

## Validation

- `.context/sigma-venv/bin/python -m py_compile bin/sigma-gen.py`
- Parsed the edited workflow YAML files with PyYAML.
- Ran `.context/sigma-venv/bin/python bin/sigma-gen.py --skip-yaml-update`; it completed and generated only actual pending Sigma output, which was restored so this PR stays focused on the workflow/generator fix.
