### PR TITLE
ci: harden npm install vs ECONNRESET + fix dependabot npm path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  # Maintain dependencies for npm
+  # Maintain dependencies for npm (Next.js site lives in /website)
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/website"
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,15 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 22.x
+        cache: 'npm'
+        cache-dependency-path: website/package-lock.json
     - name: Export site
       run: |
-        npm install
+        for attempt in 1 2 3; do
+          npm install --no-audit --no-fund --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000 && break
+          echo "npm install failed (attempt $attempt/3), retrying in 15s..."
+          sleep 15
+        done
         npm run build
       working-directory: website
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "LOLRMM",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

Fixes two CI/CD failures that surfaced this week:

1. **Deploy build failed with `npm error code ECONNRESET`** during `npm install` (the failed run from PR #200). Cause was a transient network blip while pulling registry tarballs.
2. **Dependabot has been erroring** with `dependency_file_not_found: /package.json not found`. The `npm` ecosystem block in `.github/dependabot.yml` was pointed at `/`, but the actual `package.json` lives in `/website/`.

## Changes

- **`.github/workflows/deploy.yml`**
  - Enable `actions/setup-node` npm cache (`cache: 'npm'`, `cache-dependency-path: website/package-lock.json`) so most installs hit the cache and don't have to round-trip to the registry.
  - Wrap `npm install` in a 3-attempt retry loop with a 15s pause between tries.
  - Pass `--fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000` so npm itself also retries on socket hiccups.
  - Add `--no-audit --no-fund` for less log noise.
- **`.github/dependabot.yml`**
  - Move `npm` package-ecosystem `directory:` from `/` to `/website`.
- **`package-lock.json`** (repo root) — removed. It was a stale empty stub (`{"name":"LOLRMM","lockfileVersion":3,"packages":{}}`) with no matching `package.json`; it was what dependabot kept tripping on.

## Test plan

- [ ] Watch the `Deploy site` workflow run on this PR (or after merge to `main`) and confirm `npm install` step succeeds and is now cached.
- [ ] After merge, verify the next Dependabot scan no longer reports `dependency_file_not_found` for the npm ecosystem.
- [ ] Confirm `yamllint` still passes (the `.yamllint` config ignores `.github/`, so these edits are out of scope for the linter).