### PR TITLE
ci: fix Deploy site push step and broken retry loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,16 +58,18 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git config --global push.default simple
-        git add .
+        git add detections/ website/pages/tools/ website/public/
         git diff --quiet && git diff --staged --quiet && exit 0
         git commit -m "Update generated site files [skip ci]"
         for attempt in 1 2 3; do
-          git pull --rebase origin main
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git HEAD:main && exit 0
+          if git pull --rebase origin main \
+            && git push "https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git" HEAD:main; then
+            exit 0
+          fi
+          echo "push attempt $attempt failed, retrying in $((attempt * 5))s..."
           sleep $((attempt * 5))
         done
         exit 1
-      working-directory: website
 
 # Deployment job
   deploy:

--- a/.github/workflows/sigma-gen.yml
+++ b/.github/workflows/sigma-gen.yml
@@ -40,8 +40,11 @@ jobs:
           git diff --quiet && git diff --staged --quiet && exit 0
           git commit -m "Update Sigma rules [skip ci]"
           for attempt in 1 2 3; do
-            git pull --rebase origin main
-            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:${GITHUB_REF} && exit 0
+            if git pull --rebase origin main \
+              && git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF}"; then
+              exit 0
+            fi
+            echo "push attempt $attempt failed, retrying in $((attempt * 5))s..."
             sleep $((attempt * 5))
           done
           exit 1


### PR DESCRIPTION
## Summary

The Deploy site / build job has been failing on every push since #200 (which un-broke the MDX compile) with:

```
[main 1ad4e17] Update generated site files [skip ci]
 18 files changed, 21253 insertions(+), 16990 deletions(-)
 create mode 100644 website/pages/tools/teramind.mdx
 ...
error: cannot pull with rebase: You have unstaged changes.
Error: Process completed with exit code 128.
```

Two distinct bugs in the **"Commit and push changes"** step of `.github/workflows/deploy.yml`:

### Bug 1 — wrong `working-directory` left files unstaged
The step ran with `working-directory: website`, so `git add .` only staged paths under `website/`. But `bin/site.py` also regenerates `detections/*.yml` via a `generate_detections.py` subprocess. Those files stayed unstaged in the worktree, and the next `git pull --rebase` refused to run.

### Bug 2 — the retry loop was dead code
Under `set -e` (default for `shell: bash`), the first failed `git pull --rebase` killed the step immediately. The surrounding `for attempt in 1 2 3` loop never iterated, so the recent "Fix generated workflow push races" PR #196's retry hardening did nothing in practice.

## Fix

- Drop `working-directory: website` from the commit step so git ops run at the repo root.
- Replace `git add .` with explicit paths `git add detections/ website/pages/tools/ website/public/` covering every output `bin/site.py` actually produces (verified against `site.py` + `generate_detections.py` + `generate_domains_csv.py`).
- Wrap pull+push in an `if pull && push; then exit 0; fi` block so a transient pull race no longer aborts the step under `set -e` and the retry loop actually retries.
- Apply the same `if pull && push` retry pattern to `.github/workflows/sigma-gen.yml` — identical broken pattern, identical fix.

## Verified locally

- `yaml.safe_load()` on both edited workflows
- `shellcheck` on both rewritten commit-and-push scripts

Cannot fully simulate the CI flow locally, so the actual deploy-step verification happens when this PR merges — but the failure mode and fix are mechanical.

## Out of scope (flagged by codex review)

Codex caught two further hardening opportunities I deliberately left out of this PR to keep blast radius small. Happy to follow up if you want:

- **Cross-workflow race**: `deploy.yml` and `sigma-gen.yml` both push to `main` with no shared concurrency group. With both retry loops now working, same-file race losses should resolve within 3 attempts, but a shared `concurrency: { group: main-generated-push, cancel-in-progress: false }` would eliminate the race entirely.
- **Silent subprocess failures in `bin/site.py`**: `generate_detections.py` / `generate_domains_csv.py` errors are printed but `site.py` exits 0 anyway, so a partial regeneration could be silently committed.

## Test plan

- [ ] Merge → Deploy site workflow's build job runs through the new commit step cleanly
- [ ] Auto-generated commit `Update generated site files [skip ci]` lands on main
- [ ] Deploy job succeeds and GitHub Pages updates