### PR TITLE
ci: drop unnecessary chmod step from Deploy site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,6 @@ jobs:
       run: curl -sSL https://install.python-poetry.org | python -
     - name: Install dependencies with Poetry
       run: poetry install
-    - name: Make scripts executable
-      run: chmod +x bin/*.py
     - name: Generate MDX
       run: poetry run python bin/site.py -v
 


### PR DESCRIPTION
## Summary

The Deploy site workflow is **still failing** after #201. New run on commit `7b970a6` (the empty trigger commit) showed the retry loop is now working — all 3 attempts are visible in the log — but each attempt hits the same error:

```
git add detections/ website/pages/tools/ website/public/
...
[main ce3e97b] Update generated site files [skip ci]
 22 files changed, 21883 insertions(+), 17461 deletions(-)
 create mode 100644 website/pages/tools/freshservice.mdx
 ...
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
push attempt 1 failed, retrying in 5s...
...
Process completed with exit code 1.
```

The regen commits succeed (22 files this time vs. 18 pre-#201, so the `detections/` paths I added are being captured). But **something else** is still unstaged.

## Root cause — `chmod +x bin/*.py`

The "Make scripts executable" step at `deploy.yml:28-29` runs `chmod +x bin/*.py`. Several `bin/*.py` files are committed as **100644** in this repo (verified via `git ls-tree HEAD bin/`):

```
100644 ... bin/fix_yaml_formatting.py
100755 ... bin/generate_detections.py
100755 ... bin/generate_domains_csv.py
100644 ... bin/sigma-gen.py
100755 ... bin/site.py
100644 ... bin/streamlit.py
100644 ... bin/update_badge.py
100644 ... bin/validate.py
```

`chmod +x` flips the 100644 files to 100755 in the runner worktree, producing **mode-only diffs** on `fix_yaml_formatting.py`, `sigma-gen.py`, `streamlit.py`, `update_badge.py`, `validate.py`. The "Commit and push changes" step stages explicit paths (`detections/`, `website/pages/tools/`, `website/public/`) — none of which include `bin/`. So those mode-only diffs stay unstaged, and `git pull --rebase` refuses.

## Fix

Delete the chmod step. Every script invocation in every workflow goes through `python bin/foo.py` or `poetry run python bin/foo.py` — none rely on the executable bit. The chmod was dead weight that happened to produce a failure mode.

```diff
     - name: Install dependencies with Poetry
       run: poetry install
-    - name: Make scripts executable
-      run: chmod +x bin/*.py
     - name: Generate MDX
       run: poetry run python bin/site.py -v
```

## Codex-reviewed

Verified by codex against `deploy.yml`, `site.py`, `generate_detections.py`, `generate_domains_csv.py`: chmod is the right root cause (high confidence), no other plausible unstaged-change sources exist (`generate_domains_csv.py` writes only `website/public/api/`, `npm install` outputs are gitignored, `package-lock.json` is up to date), and deleting the step is narrower and cleaner than setting `git config core.fileMode false`.

## Test plan

- [ ] Merge → push triggers Deploy site
- [ ] Build step still passes (no chmod doesn't break anything)
- [ ] Commit-and-push step succeeds — `Update generated site files [skip ci]` lands on main
- [ ] Deploy job runs and GitHub Pages updates