### PR TITLE
fix(site): EventLogTable — add CommandLine + Data columns, fix ImagePath field (closes #55)

### DIFF
--- a/website/components/card.tsx
+++ b/website/components/card.tsx
@@ -213,8 +213,10 @@ type EventLog = {
 	EventID: number;
 	ProviderName: string;
 	LogFile: string;
-	ServiceName: string;
-	ImagePath: string;
+	ServiceName?: string;
+	ImagePath?: string;
+	CommandLine?: string;
+	Data?: string;
 	Description: string;
 };
 
@@ -237,8 +239,19 @@ export function EventLogTable({ data }: { data: EventLog[] }) {
 			name: "Service Name",
 		},
 		{
-			field: "Image Path",
+			field: "ImagePath",
 			name: "Image Path",
+			render: (value) => <CodeValue value={value} />,
+		},
+		{
+			field: "CommandLine",
+			name: "Command Line",
+			render: (value) => <CodeValue value={value} />,
+		},
+		{
+			field: "Data",
+			name: "Data",
+			render: (value) => <CodeValue value={value} />,
 		},
 		{
 			field: "Description",


### PR DESCRIPTION
## Summary

Closes #55. EventLog cards on the website tool pages were missing the **Command Line** column for 4688/4697 process-creation events — @Koifman flagged this with Action1 and Access Remote PC screenshots, and the same was true across many other tool pages (PSEXEC, Atera, Ammyy Admin, every tool with a 4688 entry).

### Root cause

`website/components/card.tsx`'s `EventLogTable` had two issues:

1. **Type was missing `CommandLine` and `Data`** — even though `CommandLine` is used by 28 yamls (every 4688 process-creation event across the catalog) and `Data` is used by 9 yamls (MSI installer 11707 / install-complete events). So even if those fields arrived in the data, the component had nowhere to render them.

2. **`ImagePath` column had a stray space** — declared as `field: "Image Path"` (with a space) when the actual data field is `ImagePath`. So even 7045 service-install events with valid `ImagePath` values were rendering an empty cell.

### Fix

Three changes to `website/components/card.tsx`:

```diff
 type EventLog = {
 	EventID: number;
 	ProviderName: string;
 	LogFile: string;
-	ServiceName: string;
-	ImagePath: string;
+	ServiceName?: string;
+	ImagePath?: string;
+	CommandLine?: string;
+	Data?: string;
 	Description: string;
 };

 // ... columns array ...
 		{
-			field: "Image Path",
+			field: "ImagePath",
 			name: "Image Path",
+			render: (value) => <CodeValue value={value} />,
+		},
+		{
+			field: "CommandLine",
+			name: "Command Line",
+			render: (value) => <CodeValue value={value} />,
+		},
+		{
+			field: "Data",
+			name: "Data",
+			render: (value) => <CodeValue value={value} />,
 		},
```

- Adds `CommandLine` and `Data` as optional fields on the type
- Makes `ServiceName` and `ImagePath` optional too (not every event has them — was previously inaccurate)
- Adds `CommandLine` and `Data` columns
- Renders `ImagePath`, `CommandLine`, and `Data` via the existing `CodeValue` helper so analysts can **click-to-copy** the value straight into a hunting tool (same pattern used for cert thumbprints and file paths elsewhere)
- Fixes the `Image Path` → `ImagePath` field-name bug so the existing column actually renders

### Field-usage audit (across all 312 yamls)

| Field | Yamls using |
|---|---|
| Description | 1679 (most artifact descriptions) |
| OS | 503 (mostly Disk) |
| ProviderName | 83 |
| LogFile | 83 |
| ServiceName | 39 |
| ImagePath | 37 |
| **CommandLine** | **28** ← previously not rendered |
| **Data** | **9** ← previously not rendered |

## Test plan

- [x] `tsc --noEmit` shows no new errors (the three new render functions inherit the same `value: any` implicit-any pattern as the existing render functions elsewhere in the file — this is the project's established style for column renderers)
- [ ] Merge → next Deploy site run regenerates the tool pages → CommandLine column now visible on Action1, Access Remote PC, Atera, Ammyy Admin, PSEXEC, and the 24 other tool pages that have 4688 entries