### PR TITLE
fix(faronics): remove FP-prone *.local + bare 'insight' from Network artifacts (closes #209)

### DIFF
--- a/yaml/faronics_core.yaml
+++ b/yaml/faronics_core.yaml
@@ -74,9 +74,9 @@ Artifacts:
           Ports:
               - 80
               - 443
-        - Description: Faronics Core Server <-> Core Agent on-prem communication (administrator-supplied Core Server hostname / IP). Default Faronics Core Server listener and Core Agent ports are documented by Faronics.
+        - Description: Faronics Core Server <-> Core Agent on-prem communication. The Core Server hostname/IP is administrator-supplied (no fixed vendor domain) — hunt on TCP/7751-7752 to/from on-prem Core Server hosts and pair with the Disk / Registry / Process artifacts above. Default Faronics Core Server listener and Core Agent ports are documented by Faronics.
           Domains:
-              - '*.local'
+              - user_managed
           Ports:
               - 7751
               - 7752

--- a/yaml/faronics_insight.yaml
+++ b/yaml/faronics_insight.yaml
@@ -105,10 +105,9 @@ Artifacts:
               - docs.faronics.com
           Ports:
               - 443
-        - Description: Insight Connector intermediary host (administrator-supplied; IP, hostname, or FQDN). Default Teacher / Student communication ports are listed by Faronics in the Insight Quick Install Guide.
+        - Description: Insight Connector intermediary host. The Connector hostname/IP is administrator-supplied (no fixed vendor domain) — hunt on TCP/1313 and TCP/8080 to/from on-prem Connector hosts and pair with the FIStudentSvc / FIStudentAgent / FIStudentUI / STAHelper process artifacts above. Default Teacher / Student communication ports are listed by Faronics in the Insight Quick Install Guide.
           Domains:
-              - insight
-              - '*.local'
+              - user_managed
           Ports:
               - 1313
               - 8080


### PR DESCRIPTION
## Summary

Closes #209 — thanks @MickFly for the quick catch.

Two Faronics yamls I added in #188 had FP-prone domain entries that would match anything in a normal enterprise environment:

- `yaml/faronics_core.yaml:79` had `'*.local'` → matches every mDNS/Bonjour hostname and every Windows AD local-domain host
- `yaml/faronics_insight.yaml:110-111` had **both** `'insight'` (bare single-word, matches anything called "insight" anywhere) **and** `'*.local'`

Same class of mistake as the TrustConnect masquerade-name PEMetadata we caught in #183 — listing too-generic patterns as detection inputs produces guaranteed FPs downstream.

## Fix

Replace both with the `user_managed` sentinel (per the convention I established in `nezha.yaml` for tenant-configurable Dashboard hosts) and tighten the Description so the hunt strategy is explicit — defenders pair the documented ports (TCP/7751-7752 for Core, TCP/1313+8080 for Insight) with the Disk / Registry / Process artifacts on the host side, rather than relying on a non-existent vendor domain.

## Holistic audit also done

Swept the entire 312-yaml catalog for the same class of issue:

| Pattern checked | Hits |
|---|---|
| `'*.local'` | **2** — only the two Faronics yamls in this PR |
| Plain RFC1918 IPs (`192.168.*`, `10.*`, `172.16.*`) as Domains | 0 |
| Bare TLDs (`com`, `net`, etc.) as Domains | 0 |
| Sub-6-character domains | 0 |
| Bare single-word hostnames (no dot, no asterisk) | 6, but all are documentation-placeholder strings like `<operator-configured GLPI server>` in freshservice/glpi/rodexrmm/teramind/vizor — clearly marked, don't match anything real |

So this PR is the complete fix. No other catalog-wide cleanup needed.

## Test plan

- [x] `python3 bin/validate.py -y yaml/ -s bin/spec/lolrmm.spec.json` → No Errors found
- [ ] Merge → Faronics Insight / Core pages show `user_managed` Domains entries with the tightened Description; downstream consumers no longer ingest `*.local` or bare `insight` as detection inputs