### PR TITLE
[codex] Add LOLDrivers backlinks

### DIFF
--- a/website/pages/_meta.json
+++ b/website/pages/_meta.json
@@ -14,8 +14,14 @@
 		"href": "https://www.magicsword.io/?utm_source=lolrmm&utm_medium=website&utm_campaign=free_prevention&utm_content=nav_menu",
 		"newWindow": true
 	},
+	"loldrivers": {
+		"title": "LOLDrivers",
+		"type": "page",
+		"href": "https://loldrivers.io/",
+		"newWindow": true
+	},
 	"about": {
-		"title": "About",
+		"title": "About Us",
 		"type": "page"
 	}
 

--- a/website/pages/about.mdx
+++ b/website/pages/about.mdx
@@ -1,8 +1,14 @@
 ---
-title: "About"
+title: "About Us"
+description: "About the LOLRMM project and related Living Off The Land security research projects."
 ---
 
-# about LOLRMM?
+# About Us
+
+LOLRMM is available at <a href="https://lolrmm.io/" className="text-blue-500">lolrmm.io</a>. It is closely related to <a href="https://loldrivers.io/" className="text-blue-500">LOLDrivers</a>, a companion project for tracking malicious and vulnerable drivers.
+
+## About LOLRMM
+
 LOLRMM (Living Off the Land Remote Monitoring and Management) is a community-driven project that provides a curated list of Remote Monitoring and Management (RMM) tools that could potentially be abused by threat actors. This project aims to assist security professionals in staying informed about these tools and their potential for misuse.
 
 The project was inspired by the need to track and understand the potential security implications of legitimate RMM tools when used maliciously. By cataloging these tools and their capabilities, we hope to raise awareness and improve detection and prevention strategies in the security community.
@@ -47,5 +53,4 @@ LOLRMM is an open-source project that welcomes contributions from the security c
     <p>Currently, Jose Enrique Hernandez is the Director of Threat Research at Splunk. Jose is known for creating several security-related projects, including: <a href="https://github.com/splunk/attack_range" className="text-blue-500">Splunk Attack Range</a>, <a href="https://github.com/splunk/security_content" className="text-blue-500">Splunk Security Content</a>, <a href="https://github.com/josehelps/git-wild-hunt" className="text-blue-500">Git-Wild-Hunt</a>, <a href="https://github.com/splunk/melting-cobalt" className="text-blue-500">Melting-Cobalt</a>, and <a href="https://github.com/josehelps/blackcert" className="text-blue-500">BlackCert</a> projects. He also works as a maintainer to security industry critical repositories such as <a href="atomicredteam.io/" className="text-blue-500">Atomic Red Team</a> and <a href="lolbas-project.github.io/" className="text-blue-500">lolbas-project.github.io</a>.</p>
   </div>
 </div>
-
 


### PR DESCRIPTION
## Summary

- Add a top navigation link from LOLRMM to LOLDrivers.
- Rename the About page to About Us.
- Add About Us copy linking to both lolrmm.io and loldrivers.io.

## Impact

This gives visitors clearer cross-project navigation between LOLRMM and LOLDrivers and makes the About page explicitly reference both project sites.

## Validation

- `git diff --check`
- `npm run build` from `website/`
