### PR TITLE
[codex] Fix Teramind installer cache false positive

### DIFF
--- a/bin/lint_content.py
+++ b/bin/lint_content.py
@@ -4,9 +4,10 @@ Content lint for LOLRMM yaml catalog.
 
 Distinct from `bin/validate.py` (schema/structural).  This script checks
 intent-level quality of detection-ready fields — primarily
-Artifacts.Network[].Domains and Artifacts.Network[].Ports — and surfaces
-patterns that produce downstream false positives when ingested by SIEM /
-EDR / lookup-table consumers.
+Artifacts.Network[].Domains, Artifacts.Network[].Ports, and selected
+Artifacts.Disk[].File patterns — and surfaces patterns that produce
+downstream false positives when ingested by SIEM / EDR / lookup-table
+consumers.
 
 Two severity tiers:
 
@@ -331,6 +332,27 @@ def _check_port(file: str, idx_path: str, value: object) -> Iterable[Finding]:
         )
 
 
+def _check_disk_file(file: str, idx_path: str, value: object) -> Iterable[Finding]:
+    """Yield findings for a single Disk File entry."""
+    if not isinstance(value, str):
+        return
+
+    normalized = value.strip().replace("/", "\\").lower()
+    if normalized == r"c:\windows\installer\*.msi":
+        yield Finding(
+            ERROR,
+            file,
+            idx_path,
+            value,
+            "disk-windows-installer-msi-cache-wildcard",
+            r"C:\Windows\Installer\*.msi matches the shared Windows Installer "
+            "cache for any MSI install and produces high-volume false positives",
+            "remove this generic cache wildcard; keep vendor-specific MSI "
+            "filenames, install directories, service names, or registry "
+            "artifacts instead",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Walk
 # ---------------------------------------------------------------------------
@@ -355,7 +377,18 @@ def lint_file(path: str) -> list[Finding]:
         return []
 
     out: list[Finding] = []
-    nets = (data.get("Artifacts") or {}).get("Network") or []
+    artifacts = data.get("Artifacts") or {}
+
+    disks = artifacts.get("Disk") or []
+    if isinstance(disks, list):
+        for d_idx, disk in enumerate(disks):
+            if not isinstance(disk, dict):
+                continue
+            out.extend(_check_disk_file(
+                path, f"Artifacts.Disk[{d_idx}].File", disk.get("File"),
+            ))
+
+    nets = artifacts.get("Network") or []
     if not isinstance(nets, list):
         return out
 

--- a/yaml/teramind.yaml
+++ b/yaml/teramind.yaml
@@ -9,7 +9,7 @@ Description: 'Teramind is a US-based employee/user activity monitoring (UAM), in
     '
 Author: '@MHaggis'
 Created: '2026-05-04'
-LastModified: '2026-05-04'
+LastModified: '2026-06-15'
 Details:
     Website: https://www.teramind.co/
     PEMetadata:
@@ -103,9 +103,6 @@ Artifacts:
           OS: Windows
         - File: teramind_agent_*_ARM64.msi
           Description: Teramind agent installer MSI (ARM64) — observed signed variants include teramind_agent_v26.8.183_ARM64.msi, teramind_agent_v26.8.183_ARM64_popup.msi, teramind_agent_v26.8.183_bundle_drivers_ARM64.msi.
-          OS: Windows
-        - File: 'C:\Windows\Installer\*.msi'
-          Description: Cached MSI in the standard Windows Installer cache (e.g. C:\Windows\Installer\46a573.msi observed for a Teramind install); content-identical to the original teramind_agent_*.msi
           OS: Windows
         - File: tmagent-i(__<hash>).pkg
           Description: Teramind macOS agent PKG installer; vendor enforces a fixed filename pattern. Per-tenant identifier embedded as -i(__<hash>); renamed installers are rejected.


### PR DESCRIPTION
## Summary
- Remove the generic `C:\Windows\Installer\*.msi` Disk artifact from `yaml/teramind.yaml`.
- Add a content-lint guard so the shared Windows Installer MSI cache wildcard cannot be reintroduced in another YAML.
- Keep generated Sigma files out of the PR; they regenerate from YAML after merge.

Closes #218.

## Validation
- `python3 -m yamllint -c .yamllint yaml`
- `python3 bin/validate.py -y yaml/ -s bin/spec/lolrmm.spec.json`
- `python3 bin/lint_content.py -y yaml`
- `python3 -m py_compile bin/lint_content.py`
- Temp Sigma generation for Teramind confirmed no `C:\Windows\Installer\*.msi` selector.
- Source search confirmed no YAML still uses the exact generic cache wildcard.