### PR TITLE
Deduplicate RMM domain export

### DIFF
--- a/bin/generate_domains_csv.py
+++ b/bin/generate_domains_csv.py
@@ -10,7 +10,10 @@ import yaml
 import csv
 import glob
 import re
-from pathlib import Path
+
+
+PLACEHOLDER_RE = re.compile(r"^<[^>]+>$")
+SENTINEL_VALUES = {"user_managed", "user-managed"}
 
 
 def clean_tool_name(filename):
@@ -25,6 +28,15 @@ def clean_tool_name(filename):
     name = name.replace("__", "_")
 
     return name.strip()
+
+
+def should_export_domain(domain):
+    """Return True when a Domains value is a real CSV lookup candidate."""
+    if not isinstance(domain, str):
+        return False
+
+    value = domain.strip()
+    return bool(value) and value not in SENTINEL_VALUES and not PLACEHOLDER_RE.match(value)
 
 
 def extract_domains(yaml_file_path):
@@ -44,8 +56,10 @@ def extract_domains(yaml_file_path):
             for network in data["Artifacts"]["Network"]:
                 if "Domains" in network:
                     for domain in network["Domains"]:
-                        # Only add the domain if it's not empty or 'user_managed'
-                        if domain and domain != "user_managed":
+                        # Only export real lookup values; placeholders document
+                        # operator-supplied infrastructure and do not belong in CSV.
+                        if should_export_domain(domain):
+                            domain = domain.strip()
                             domains.append((domain, tool_name))
                             print(f"Found domain: {domain} for tool: {tool_name}")
 
@@ -60,7 +74,7 @@ def generate_csv(yaml_dir, output_file):
     all_domains = []
 
     # Find all YAML files in the directory
-    yaml_files = glob.glob(os.path.join(yaml_dir, "*.y*ml"))
+    yaml_files = sorted(glob.glob(os.path.join(yaml_dir, "*.y*ml")))
     print(f"Found {len(yaml_files)} YAML files in {yaml_dir}")
 
     # Extract domains from each YAML file
@@ -68,15 +82,28 @@ def generate_csv(yaml_dir, output_file):
         domains = extract_domains(yaml_file)
         all_domains.extend(domains)
 
+    unique_domains = []
+    seen = set()
+    for domain, tool in all_domains:
+        key = (domain, tool)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_domains.append((domain, tool))
+
     # Write domains to CSV file
     with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile, lineterminator="\n")
         writer.writerow(["URI", "RMM_Tool"])
-        for domain, tool in all_domains:
+        for domain, tool in unique_domains:
             writer.writerow([domain, tool])
 
-    print(f"CSV file generated at {output_file} with {len(all_domains)} domains")
-    return len(all_domains)
+    removed = len(all_domains) - len(unique_domains)
+    print(
+        f"CSV file generated at {output_file} with {len(unique_domains)} domains "
+        f"({removed} duplicate rows removed)"
+    )
+    return len(unique_domains)
 
 
 if __name__ == "__main__":

--- a/bin/lint_content.py
+++ b/bin/lint_content.py
@@ -353,6 +353,39 @@ def _check_disk_file(file: str, idx_path: str, value: object) -> Iterable[Findin
         )
 
 
+def _check_duplicate_values(
+    file: str,
+    idx_path: str,
+    values: list[object],
+    rule: str,
+) -> Iterable[Finding]:
+    """Yield findings for duplicate values inside one list field."""
+    seen: dict[tuple[str, object], int] = {}
+
+    for idx, value in enumerate(values):
+        normalized = value.strip() if isinstance(value, str) else value
+        if isinstance(normalized, (str, int, float, bool, type(None))):
+            key = (type(normalized).__name__, normalized)
+        else:
+            key = (type(normalized).__name__, repr(normalized))
+        if key in seen:
+            yield Finding(
+                ERROR,
+                file,
+                f"{idx_path}[{idx}]",
+                repr(value),
+                rule,
+                (
+                    f"exact duplicate of {idx_path}[{seen[key]}]; "
+                    "repeated values inflate generated lookups and detections without adding signal"
+                ),
+                "remove the repeated entry",
+            )
+            continue
+
+        seen[key] = idx
+
+
 # ---------------------------------------------------------------------------
 # Walk
 # ---------------------------------------------------------------------------
@@ -377,6 +410,16 @@ def lint_file(path: str) -> list[Finding]:
         return []
 
     out: list[Finding] = []
+    details = data.get("Details") or {}
+    install_paths = details.get("InstallationPaths") or []
+    if isinstance(install_paths, list):
+        out.extend(_check_duplicate_values(
+            path,
+            "Details.InstallationPaths",
+            install_paths,
+            "duplicate-installation-path",
+        ))
+
     artifacts = data.get("Artifacts") or {}
 
     disks = artifacts.get("Disk") or []
@@ -395,11 +438,27 @@ def lint_file(path: str) -> list[Finding]:
     for n_idx, net in enumerate(nets):
         if not isinstance(net, dict):
             continue
-        for d_idx, dom in enumerate(net.get("Domains") or []):
+        domains = net.get("Domains") or []
+        if isinstance(domains, list):
+            out.extend(_check_duplicate_values(
+                path,
+                f"Artifacts.Network[{n_idx}].Domains",
+                domains,
+                "duplicate-network-domain",
+            ))
+        for d_idx, dom in enumerate(domains):
             out.extend(_check_domain(
                 path, f"Artifacts.Network[{n_idx}].Domains[{d_idx}]", dom,
             ))
-        for p_idx, port in enumerate(net.get("Ports") or []):
+        ports = net.get("Ports") or []
+        if isinstance(ports, list):
+            out.extend(_check_duplicate_values(
+                path,
+                f"Artifacts.Network[{n_idx}].Ports",
+                ports,
+                "duplicate-network-port",
+            ))
+        for p_idx, port in enumerate(ports):
             out.extend(_check_port(
                 path, f"Artifacts.Network[{n_idx}].Ports[{p_idx}]", port,
             ))

--- a/yaml/atera.yaml
+++ b/yaml/atera.yaml
@@ -4,7 +4,7 @@ Description: 'Atera is a remote monitoring and management (RMM) tool. It is used
 
     '
 Created: '2024-08-03'
-LastModified: '2025-12-14'
+LastModified: '2026-06-16'
 Details:
     Website: https://www.atera.com/
     PEMetadata:
@@ -37,7 +37,6 @@ Details:
         - '*\AgentPackageTaskScheduler.exe'
         - '*\ATERA Networks\AteraAgent\*'
         - '*\AteraAgent.exe'
-        - atera_agent.exe
         - atera_agent.exe
         - ateraagent.exe
         - C:\Program Files\ATERA Networks\AteraAgent\*

--- a/yaml/fixme.yaml
+++ b/yaml/fixme.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: FixMe.it is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://fixme.it/'
     PEMetadata:
@@ -24,7 +24,6 @@ Details:
         - TiExpertCore.exe
         - FixMeit Unattended Access Setup.exe
         - FixMeit Expert Setup.exe
-        - TiExpertCore.exe
         - fixmeitclient.exe
         - TiClientCore.exe
         - TiClientHelper*.exe

--- a/yaml/free_ping_tool.yaml
+++ b/yaml/free_ping_tool.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: Free Ping Tool is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-06-16'
 Details:
     Website: ''
     PEMetadata:
@@ -17,7 +17,6 @@ Details:
     Capabilities: []
     Vulnerabilities: []
     InstallationPaths:
-        - can't find this one
         - can't find this one
 Artifacts:
     Disk: []

--- a/yaml/instant_housecall.yaml
+++ b/yaml/instant_housecall.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: Instant Housecall is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2025-12-14'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://instanthousecall.com/'
     PEMetadata:
@@ -19,7 +19,6 @@ Details:
     InstallationPaths:
         - hsloader.exe
         - ihcserver.exe
-        - instanthousecall.exe
         - instanthousecall.exe
 Artifacts:
     Disk: []

--- a/yaml/logmein_rescue.yaml
+++ b/yaml/logmein_rescue.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: LogMeIn rescue is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2025-12-14'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://www.logmein.com/products/rescue'
     PEMetadata:
@@ -22,7 +22,6 @@ Details:
         - lmi_rescue.exe
         - C:\Users\*\AppData\Local\LogMeIn Rescue Applet\LMIR*.tmp\lmi_rescue.exe
         - C:\Users\*\AppData\Local\LogMeIn Rescue Applet\LMIR*.tmp\lmi_rescue_srv.exe
-        - C:\Users\*\AppData\Local\LogMeIn Rescue Applet\LMIR*.tmp\lmi_rescue.exe
 Artifacts:
     Disk: []
     EventLog: []

--- a/yaml/mocha_vnc_lite.yaml
+++ b/yaml/mocha_vnc_lite.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: Mocha VNC Lite is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-06-16'
 Details:
     Website: ''
     PEMetadata:
@@ -17,7 +17,6 @@ Details:
     Capabilities: []
     Vulnerabilities: []
     InstallationPaths:
-        - This installs a modified VNC and cannot be blocked by path separate from VNC
         - This installs a modified VNC and cannot be blocked by path separate from VNC
         - '*\RealVNC\VNC4\*'
 Artifacts:

--- a/yaml/mremoteng.yaml
+++ b/yaml/mremoteng.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: mRemoteNG is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://mremoteng.org/'
     PEMetadata:
@@ -24,7 +24,6 @@ Details:
         - c:\Program Files (x86)%\mRemoteNG
         - '*%\mRemoteNG'
         - mRemoteNG-Installer-*.msi
-        - '*\mRemoteNG.exe'
 Artifacts:
     Disk:
         - File: C:\Users\*\AppData\Roaming\mRemoteNG\mRemoteNG.log

--- a/yaml/multcloud.yaml
+++ b/yaml/multcloud.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: MultCloud is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://www.multcloud.com/'
     PEMetadata:
@@ -17,7 +17,6 @@ Details:
     Capabilities: []
     Vulnerabilities: []
     InstallationPaths:
-        - requires sign up
         - requires sign up
 Artifacts:
     Disk: []

--- a/yaml/ninjarmm.yaml
+++ b/yaml/ninjarmm.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: NinjaRMM is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2026-01-27'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://www.ninjaone.com/rmm/'
     PEMetadata:
@@ -33,8 +33,6 @@ Artifacts:
               - ninjaone.com
               - ninjarmm.net
               - '*.ninjarmm.net'
-              - rmmservice.eu
-              - '*.rmmservice.eu'
               - rmmservice.eu
               - '*.rmmservice.eu'
               - rmmservice.com.au

--- a/yaml/screenconnect.yaml
+++ b/yaml/screenconnect.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: ScreenConnect is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: Ali Alwashali, Nasreddine Bencherchali
 Created: '2023-10-01'
-LastModified: '2023-10-01'
+LastModified: '2026-06-16'
 Details:
     Website: https://www.connectwise.com
     PEMetadata:
@@ -39,11 +39,8 @@ Details:
         - '*\*\ScreenConnect.WindowsClient.exe'
         - screenconnect*.exe
         - screenconnect.windowsclient.exe
-        - Remote Workforce Client.exe
-        - screenconnect*.exe
         - ConnectWiseControl*.exe
         - connectwise*.exe
-        - screenconnect.windowsclient.exe
         - screenconnect.clientservice.exe
 Artifacts:
     Disk:

--- a/yaml/tactical_rmm.yaml
+++ b/yaml/tactical_rmm.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: Tactical RMM is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2025-12-14'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://docs.tacticalrmm.com/'
     PEMetadata:
@@ -18,7 +18,6 @@ Details:
     Vulnerabilities: []
     InstallationPaths:
         - tacticalrmm.exe
-        - tacticalrmm.exe
 Artifacts:
     Disk: []
     EventLog: []
@@ -26,7 +25,6 @@ Artifacts:
     Network:
         - Description: Known remote domains
           Domains:
-              - login.tailscale.com
               - login.tailscale.com
               - docs.tacticalrmm.com
           Ports: []

--- a/yaml/ultraviewer.yaml
+++ b/yaml/ultraviewer.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: UltraViewer is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2025-12-14'
+LastModified: '2026-06-16'
 Details:
     Website: 'https://www.ultraviewer.net/'
     PEMetadata:
@@ -26,9 +26,6 @@ Details:
         - '*\UltraViewer_Desktop.exe'
         - ultraviewer_desktop.exe
         - ultraviewer_service.exe
-        - UltraViewer_Desktop.exe
-        - UltraViewer_setup*
-        - UltraViewer_Service.exe
 Artifacts:
     Disk: []
     EventLog: []


### PR DESCRIPTION
## Summary
- Deduplicate exact `(URI, RMM_Tool)` rows when generating `rmm_domains.csv`
- Skip sentinel and angle-bracket placeholder values from the domain CSV export
- Remove exact duplicate YAML list entries found during a broader catalog scan
- Add content-lint checks to prevent duplicate values inside InstallationPaths, Network Domains, and Network Ports lists

Generated site/API artifacts were not committed; the existing automation can rebuild them after merge.

## Validation
- `python3 -m py_compile bin/generate_domains_csv.py bin/lint_content.py`
- `python3 -m yamllint -c .yamllint yaml/ninjarmm.yaml yaml/tactical_rmm.yaml yaml/atera.yaml yaml/fixme.yaml yaml/free_ping_tool.yaml yaml/instant_housecall.yaml yaml/logmein_rescue.yaml yaml/mocha_vnc_lite.yaml yaml/mremoteng.yaml yaml/multcloud.yaml yaml/screenconnect.yaml yaml/ultraviewer.yaml`
- `python3 bin/validate.py -y yaml/ -s bin/spec/lolrmm.spec.json`
- `python3 bin/lint_content.py -y yaml` (0 errors, existing 11 public-IP warnings)
- Temp `rmm_domains.csv` rebuild: 657 rows, 0 duplicate rows, 0 placeholders, 0 sentinels
- Same-list scan: 0 duplicate groups across InstallationPaths, Network Domains, and Network Ports
- `git diff --check`
