### PR TITLE
fix: correct typos in RMM tool installation paths

### DIFF
--- a/yaml/absolute_(computrace).yaml
+++ b/yaml/absolute_(computrace).yaml
@@ -19,7 +19,7 @@ Details:
     InstallationPaths:
         - rpcnet.exe
         - ctes.exe
-        - ctespersitence.exe
+        - ctespersistence.exe
         - cteshostsvc.exe
         - rpcld.exe
 Artifacts:

--- a/yaml/absolute_(computrace).yaml
+++ b/yaml/absolute_(computrace).yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: Absolute (Computrace) is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-09-02'
 Details:
     Website: 'https://www.absolute.com/'
     PEMetadata:

--- a/yaml/ericom_connect.yaml
+++ b/yaml/ericom_connect.yaml
@@ -18,7 +18,7 @@ Details:
     Vulnerabilities: []
     InstallationPaths:
         - EricomConnectRemoteHost*.exe
-        - ericomconnnectconfigurationtool.exe
+        - ericomconnectconfigurationtool.exe
 Artifacts:
     Disk: []
     EventLog: []

--- a/yaml/ericom_connect.yaml
+++ b/yaml/ericom_connect.yaml
@@ -3,7 +3,7 @@ Category: RMM
 Description: Ericom Connect is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2025-12-14'
+LastModified: '2026-09-02'
 Details:
     Website: 'https://www.ericom.com/connect-accessnow/'
     PEMetadata:

--- a/yaml/nomachine.yaml
+++ b/yaml/nomachine.yaml
@@ -18,7 +18,7 @@ Details:
     Vulnerabilities: []
     InstallationPaths:
         - nomachine*.exe
-        - nxservice*.ese
+        - nxservice*.exe
         - nxd.exe
 Artifacts:
     Disk: []

--- a/yaml/nomachine.yaml
+++ b/yaml/nomachine.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: NoMachine is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-09-02'
 Details:
     Website: 'https://www.nomachine.com/'
     PEMetadata:

--- a/yaml/rdp2tcp.yaml
+++ b/yaml/rdp2tcp.yaml
@@ -18,7 +18,7 @@ Details:
     Capabilities: []
     Vulnerabilities: []
     InstallationPaths:
-        - tdp2tcp.exe
+        - rdp2tcp.exe
         - rdp2tcp.py
 Artifacts:
     Disk: []

--- a/yaml/rdp2tcp.yaml
+++ b/yaml/rdp2tcp.yaml
@@ -3,7 +3,7 @@ Category: RAT
 Description: rdp2tcp is a remote monitoring and management (RMM) tool. More information will be added as it becomes available.
 Author: ''
 Created: '2024-08-02'
-LastModified: '2024-08-02'
+LastModified: '2026-09-02'
 Details:
     Website: 'https://github.com/V-E-O/rdp2tcp'
     PEMetadata:


### PR DESCRIPTION
Corrects four reported typos in tool YAML installation paths:

- nomachine: `nxservice*.exe` (was `.ese`)
- absolute-computrace: `ctespersistence.exe` (was `ctespersitence.exe`)
- ericom-connect: `ericomconnectconfigurationtool.exe` (was `ericomconnnectconfigurationtool.exe`)
- rdp2tcp: `rdp2tcp.exe` (was `tdp2tcp.exe`)

The four `LastModified` values are updated to `2026-09-02`. Generated site and detection files will be refreshed by the repository workflows after merge.
