### PR TITLE
Anchor process names and deduplicate values in generated Sigma rules

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,5 +38,7 @@ jobs:
       run: curl -sSL https://install.python-poetry.org | python -
     - name: Install dependencies with Poetry
       run: poetry install --no-root
+    - name: Run Sigma generator unit tests
+      run: poetry run python -m unittest discover -s tests -p 'test_sigma_gen.py'
     - name: Run YAML Checks
       run: poetry run python bin/validate.py -v

--- a/bin/sigma-gen.py
+++ b/bin/sigma-gen.py
@@ -63,6 +63,19 @@ def normalize_rule(rule: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+def semantic_rule(rule: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the rule content used to decide whether a rule changed.
+
+    IDs and dates identify a published generated rule; they are not detection
+    semantics.  Keeping them out of this comparison lets the generator retain
+    stable metadata while only updating ``modified`` for meaningful changes.
+    """
+    normalized = normalize_rule(rule)
+    for key in ("id", "date", "modified"):
+        normalized.pop(key, None)
+    return normalized
+
+
 def load_existing_sigma_rule(filepath: str) -> Tuple[Optional[Dict[str, Any]], bool]:
     """Load a Sigma rule and report whether the source file needs rewriting."""
     if not os.path.exists(filepath):
@@ -90,34 +103,60 @@ class IndentDumper(yaml.SafeDumper):
         return super().increase_indent(flow, False)
 
 
+def dedupe(values: List[str]) -> List[str]:
+    """Drop case-insensitive duplicates while keeping the first spelling."""
+    seen = set()
+    unique = []
+    for value in values:
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(value)
+    return unique
+
+
+def anchor_filename(filename: str) -> str:
+    """Require a Windows path separator immediately before an executable name.
+
+    Both ordinary and wildcard-prefixed basenames need the separator.  Sigma
+    requires a backslash before a wildcard to be escaped, so the Python value
+    deliberately contains two backslashes before every basename, including
+    ``*.exe``.
+    """
+    return f"\\\\{filename}"
+
+
 def extract_artifacts(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
     artifacts = {"files": [], "registry": [], "network": [], "processes": []}
 
     for item in yaml_data.get("Artifacts", {}).get("Disk", []) or []:
-        if isinstance(item, dict) and "File" in item:
+        if isinstance(item, dict) and isinstance(item.get("File"), str):
             artifacts["files"].append(item["File"])
 
     for item in yaml_data.get("Artifacts", {}).get("Registry", []) or []:
-        if isinstance(item, dict) and "Path" in item:
+        if isinstance(item, dict) and isinstance(item.get("Path"), str):
             artifacts["registry"].append(item["Path"])
 
     for item in yaml_data.get("Artifacts", {}).get("Network", []) or []:
         if isinstance(item, dict):
             if "Domains" in item:
                 if isinstance(item["Domains"], list):
-                    artifacts["network"].extend(item["Domains"])
+                    artifacts["network"].extend(
+                        domain for domain in item["Domains"] if isinstance(domain, str)
+                    )
                 elif isinstance(item["Domains"], str):
                     artifacts["network"].append(item["Domains"])
 
     details = yaml_data.get("Details", {})
     if isinstance(details, dict):
         artifacts["processes"] = [
-            ntpath.basename(item)
+            anchor_filename(ntpath.basename(item))
             for item in details.get("InstallationPaths", []) or []
             if isinstance(item, str) and item.lower().endswith(".exe")
         ]
 
-    return artifacts
+    return {key: dedupe(values) for key, values in artifacts.items()}
 
 
 def write_sigma_rule(rule: Dict[str, Any], filepath: str) -> None:
@@ -201,7 +240,12 @@ def write_sigma_rule_if_changed(rule: Dict[str, Any], filepath: str) -> None:
         rule["id"] = str(existing_rule.get("id", rule["id"]))
         if "date" in existing_rule:
             rule["date"] = yaml_date(existing_rule["date"])
-        if "modified" in existing_rule:
+
+        if semantic_rule(existing_rule) != semantic_rule(rule):
+            # Detection and other semantic content changed, so this is a new
+            # revision of the published rule.  Preserve the original date/ID.
+            rule["modified"] = date.today().strftime("%Y-%m-%d")
+        elif "modified" in existing_rule:
             rule["modified"] = yaml_date(existing_rule["modified"])
 
         if not needs_rewrite and normalize_rule(existing_rule) == normalize_rule(rule):
@@ -271,7 +315,7 @@ def generate_sigma_rules(yaml_file: str, output_dir: str) -> List[Dict[str, Any]
                 "references": ["https://github.com/magicsword-io/LOLRMM"],
                 "author": "LOLRMM Project",
                 "date": date.today().strftime("%Y-%m-%d"),
-                "tags": ["attack.execution", "attack.t1219"],
+                "tags": ["attack.command-and-control", "attack.t1219"],
                 "logsource": rule_template["logsource"],
                 "detection": detection,
                 "falsepositives": [f"Legitimate use of {name}"],
@@ -340,15 +384,30 @@ def update_yaml_with_sigma_rules(
         )
 
 
-def main(update_yaml: bool = True) -> None:
-    yaml_dir = "yaml/"
-    output_dir = "detections/sigma/"
+def main(
+    update_yaml: bool = True,
+    yaml_dir: str = "yaml/",
+    output_dir: str = "detections/sigma/",
+) -> None:
     os.makedirs(output_dir, exist_ok=True)
 
-    for filename in os.listdir(yaml_dir):
+    # Sorting makes generation reproducible.  Duplicate Names produce the
+    # same output path; warn so the deterministic last writer is visible.
+    written_by: Dict[str, str] = {}
+    for filename in sorted(os.listdir(yaml_dir)):
         if filename.endswith(".yaml") or filename.endswith(".yml"):
             yaml_file = os.path.join(yaml_dir, filename)
             sigma_rules = generate_sigma_rules(yaml_file, output_dir)
+            for generated_rule in sigma_rules:
+                output_file = generated_rule["Sigma"][len(SIGMA_RULE_PREFIX) :]
+                previous = written_by.get(output_file)
+                if previous:
+                    print(
+                        f"[!] Duplicate tool Name: {yaml_file} overwrote {output_file} "
+                        f"previously generated from {previous}. Give the tools distinct "
+                        "Names or merge their artifacts."
+                    )
+                written_by[output_file] = yaml_file
             if update_yaml:
                 update_yaml_with_sigma_rules(yaml_file, sigma_rules)
 

--- a/tests/test_sigma_gen.py
+++ b/tests/test_sigma_gen.py
@@ -1,0 +1,167 @@
+"""Focused regression tests for the Sigma rule generator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("sigma_gen", ROOT / "bin" / "sigma-gen.py")
+assert SPEC and SPEC.loader
+sigma_gen = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sigma_gen)
+
+
+def sample_rule() -> dict:
+    return {
+        "title": "Potential Example RMM Tool Process Activity",
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "experimental",
+        "description": "Detects example process activity",
+        "references": ["https://github.com/magicsword-io/LOLRMM"],
+        "author": "LOLRMM Project",
+        "date": "2020-01-01",
+        "tags": ["attack.command-and-control", "attack.t1219"],
+        "logsource": {"product": "windows", "category": "process_creation"},
+        "detection": {
+            "selection": {"Image|endswith": ["\\\\example.exe"]},
+            "condition": "selection",
+        },
+        "falsepositives": ["Legitimate use of Example"],
+        "level": "medium",
+    }
+
+
+class SigmaGeneratorTests(unittest.TestCase):
+    def test_anchors_ordinary_filename_with_escaped_separator(self) -> None:
+        artifacts = sigma_gen.extract_artifacts(
+            {"Details": {"InstallationPaths": [r"C:\Program Files\Example\rd.exe"]}}
+        )
+
+        self.assertEqual(artifacts["processes"], [r"\\rd.exe"])
+
+    def test_anchors_leading_wildcard_filename_with_escaped_separator(self) -> None:
+        artifacts = sigma_gen.extract_artifacts(
+            {"Details": {"InstallationPaths": [r"C:\Program Files\Example\*.exe"]}}
+        )
+
+        self.assertEqual(artifacts["processes"], [r"\\*.exe"])
+
+    def test_anchors_embedded_wildcard_filename_with_escaped_separator(self) -> None:
+        artifacts = sigma_gen.extract_artifacts(
+            {"Details": {"InstallationPaths": [r"C:\Program Files\RuDesktop\rudesktop*.exe"]}}
+        )
+
+        self.assertEqual(artifacts["processes"], [r"\\rudesktop*.exe"])
+
+    def test_deduplicates_case_insensitively_and_preserves_first_spelling(self) -> None:
+        values = ["Example.EXE", "example.exe", "EXAMPLE.exe", "Other.exe"]
+
+        self.assertEqual(sigma_gen.dedupe(values), ["Example.EXE", "Other.exe"])
+
+    def test_generated_rules_use_remote_access_attack_tags(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "tool.yaml"
+            source.write_text(
+                yaml.safe_dump(
+                    {
+                        "Name": "Example Tool",
+                        "Artifacts": {"Network": [{"Domains": ["example.test"]}]},
+                        "Details": {"InstallationPaths": [r"C:\Tools\example.exe"]},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            sigma_gen.generate_sigma_rules(str(source), str(root))
+
+            for rule_path in root.glob("*_sigma.yml"):
+                rule = yaml.safe_load(rule_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    rule["tags"], ["attack.command-and-control", "attack.t1219"]
+                )
+                self.assertNotIn("attack.execution", rule["tags"])
+
+    def test_unchanged_rule_is_not_rewritten(self) -> None:
+        rule = sample_rule()
+        with TemporaryDirectory() as directory:
+            rule_path = Path(directory) / "rule.yml"
+            sigma_gen.write_sigma_rule(rule, str(rule_path))
+
+            with patch.object(sigma_gen, "write_sigma_rule") as write_rule:
+                sigma_gen.write_sigma_rule_if_changed(copy.deepcopy(rule), str(rule_path))
+
+            write_rule.assert_not_called()
+
+    def test_semantic_change_preserves_identity_and_updates_modified(self) -> None:
+        original = sample_rule()
+        with TemporaryDirectory() as directory:
+            rule_path = Path(directory) / "rule.yml"
+            sigma_gen.write_sigma_rule(original, str(rule_path))
+
+            changed = copy.deepcopy(original)
+            changed["id"] = "22222222-2222-2222-2222-222222222222"
+            changed["date"] = "2026-01-01"
+            changed["detection"]["selection"]["Image|endswith"] = [r"\\changed.exe"]
+            sigma_gen.write_sigma_rule_if_changed(changed, str(rule_path))
+
+            written = yaml.safe_load(rule_path.read_text(encoding="utf-8"))
+            self.assertEqual(written["id"], original["id"])
+            self.assertEqual(str(written["date"]), original["date"])
+            self.assertEqual(str(written["modified"]), sigma_gen.date.today().isoformat())
+
+    def test_new_rule_has_no_modified_date(self) -> None:
+        with TemporaryDirectory() as directory:
+            rule_path = Path(directory) / "rule.yml"
+            sigma_gen.write_sigma_rule_if_changed(sample_rule(), str(rule_path))
+
+            written = yaml.safe_load(rule_path.read_text(encoding="utf-8"))
+            self.assertNotIn("modified", written)
+
+    def test_sorted_collision_warning_and_repeated_generation_are_deterministic(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            yaml_dir = root / "yaml"
+            output_dir = root / "sigma"
+            yaml_dir.mkdir()
+
+            for filename, executable in (("z-last.yaml", "z.exe"), ("a-first.yaml", "a.exe")):
+                (yaml_dir / filename).write_text(
+                    yaml.safe_dump(
+                        {
+                            "Name": "Shared Tool",
+                            "Details": {"InstallationPaths": [rf"C:\Tools\{executable}"]},
+                        },
+                        sort_keys=False,
+                    ),
+                    encoding="utf-8",
+                )
+
+            first_output = io.StringIO()
+            with redirect_stdout(first_output):
+                sigma_gen.main(False, str(yaml_dir), str(output_dir))
+            generated = output_dir / "shared_tool_processes_sigma.yml"
+            first_bytes = generated.read_bytes()
+
+            second_output = io.StringIO()
+            with redirect_stdout(second_output):
+                sigma_gen.main(False, str(yaml_dir), str(output_dir))
+
+            self.assertIn("Duplicate tool Name", first_output.getvalue())
+            self.assertIn("a-first.yaml", first_output.getvalue())
+            self.assertEqual(generated.read_bytes(), first_bytes)
+            self.assertEqual(second_output.getvalue(), first_output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #236.

`bin/sigma-gen.py` was passing bare executable names to `Image|endswith` and `ParentImage|endswith`. A rule for `rd.exe` could therefore also match names such as `Standard.exe` or `keyboard.exe`. Process basenames are now anchored to a Windows path separator, including names that contain wildcards.

This update also:

- removes duplicate generated values case-insensitively while keeping the first spelling
- sorts YAML input and warns when duplicate tool names write to the same output file
- uses `attack.command-and-control` with the parent `attack.t1219` technique; the generator no longer applies a blanket Execution tag
- preserves published rule IDs and original dates, and only updates `modified` when rule content changes
- adds focused regression tests and runs them in the existing validation workflow

Only the generator, tests, and validation workflow are included here. Generated Sigma files are left to the repository automation after merge, which keeps this PR small and avoids stale generated-file conflicts.

Validation completed:

- 9 generator regression tests pass
- repository YAML validation passes
- content lint: 0 errors, 11 existing warnings
- two complete generator runs produced identical output across 643 Sigma files
- all 592 source-managed generated rules pass the current Sigma JSON schema
- sigma-cli 3.1.0 reports 0 rule errors and 0 condition errors across the complete generated set

This builds on the original investigation and implementation by @clivoa.
