### PR TITLE
fix(ci): regenerate files instead of rebasing to avoid deploy push conflicts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,14 +58,21 @@ jobs:
         git config --global push.default simple
         git add detections/ website/pages/tools/ website/public/
         git diff --quiet && git diff --staged --quiet && exit 0
-        git commit -m "Update generated site files [skip ci]"
         for attempt in 1 2 3; do
-          if git pull --rebase origin main \
-            && git push "https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git" HEAD:main; then
+          # Committed content is fully generated, so instead of rebasing (which
+          # conflicts on generated files), reset to latest main and regenerate.
+          git fetch origin main
+          git reset --hard origin/main
+          poetry run python bin/site.py -v
+          git add detections/ website/pages/tools/ website/public/
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No generated changes to commit."
             exit 0
           fi
-          # Clean up half-finished rebase state so the next retry's `git pull --rebase` doesn't fail with "unmerged files"
-          git rebase --abort 2>/dev/null || true
+          git commit -m "Update generated site files [skip ci]"
+          if git push "https://x-access-token:${GITHUB_TOKEN}@github.com/magicsword-io/LOLRMM.git" HEAD:main; then
+            exit 0
+          fi
           echo "push attempt $attempt failed, retrying in $((attempt * 5))s..."
           sleep $((attempt * 5))
         done

--- a/.github/workflows/sigma-gen.yml
+++ b/.github/workflows/sigma-gen.yml
@@ -39,14 +39,21 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add detections/sigma/*.yml
           git diff --quiet && git diff --staged --quiet && exit 0
-          git commit -m "Update Sigma rules [skip ci]"
           for attempt in 1 2 3; do
-            if git pull --rebase origin main \
-              && git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF}"; then
+            # Committed content is fully generated, so instead of rebasing (which
+            # conflicts on generated files), reset to latest main and regenerate.
+            git fetch origin main
+            git reset --hard origin/main
+            python bin/sigma-gen.py --skip-yaml-update
+            git add detections/sigma/*.yml
+            if git diff --quiet && git diff --staged --quiet; then
+              echo "No generated changes to commit."
               exit 0
             fi
-            # Clean up half-finished rebase state so the next retry's `git pull --rebase` doesn't fail with "unmerged files"
-            git rebase --abort 2>/dev/null || true
+            git commit -m "Update Sigma rules [skip ci]"
+            if git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF}"; then
+              exit 0
+            fi
             echo "push attempt $attempt failed, retrying in $((attempt * 5))s..."
             sleep $((attempt * 5))
           done

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -30,9 +30,18 @@ jobs:
           git config --global push.default simple
           git add rmm-tools-count.json
           git diff --quiet && git diff --staged --quiet && exit 0
-          git commit -m "Update RMM Tools count badge"
           for attempt in 1 2 3; do
-            git pull --rebase origin main
+            # Committed content is fully generated, so instead of rebasing (which
+            # conflicts on generated files), reset to latest main and regenerate.
+            git fetch origin main
+            git reset --hard origin/main
+            python bin/update_badge.py
+            git add rmm-tools-count.json
+            if git diff --quiet && git diff --staged --quiet; then
+              echo "No generated changes to commit."
+              exit 0
+            fi
+            git commit -m "Update RMM Tools count badge"
             git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:${GITHUB_REF} && exit 0
             sleep $((attempt * 5))
           done


### PR DESCRIPTION
## Problem
The Deploy workflow failed repeatedly: it commits generated files, then `git pull --rebase` onto a main that had moved on. The generated files (`detections/sigma/rmm_domains_dns_queries.yml`, `website/public/api/detections/sigma/rmm_domains_dns_queries.yml`) conflicted on every retry, and retries just replayed the same doomed rebase.

## Fix
Since the committed content is fully generated, rebasing it is unnecessary. Each push retry now:
1. Fetches and hard-resets to latest `origin/main`
2. **Regenerates** the files (`bin/site.py` / `bin/sigma-gen.py` / `bin/update_badge.py`)
3. Commits fresh (or exits cleanly if nothing changed) and pushes

Regenerated content derived from latest main can never conflict.

Applied the same fix to all three workflows with this pattern:
- `deploy.yml`
- `sigma-gen.yml`
- `update-badge.yml`